### PR TITLE
Feat: 활동 로그 저장 기능 추가

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLogAspect.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLogAspect.java
@@ -1,2 +1,76 @@
-package com.explorer.gabom.domain.activity.aop;public class ActivityLogAspect {
+package com.explorer.gabom.domain.activity.aop;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.explorer.gabom.domain.activity.repository.ActivityLogRepository;
+import com.explorer.gabom.domain.activity.type.ActivityType;
+import com.explorer.gabom.domain.user.entity.User;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ActivityLogAspect {
+
+	private final ActivityLogRepository activityLogRepository;
+	private final HttpServletRequest request;
+
+	@AfterReturning(
+		pointcut = "@annotation(com.explorer.gabom.domain.activity.aop.ActivityLoggable)",
+		returning = "result"
+	)
+	public void logActivity(JoinPoint joinPoint, Object result) {
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		ActivityLoggable activityLoggable = signature.getMethod().getAnnotation(ActivityLoggable.class);
+		ActivityType activityType = activityLoggable.value();
+
+		Long userId = extractUserId();
+		Long targetId = null;
+
+		Object[] args = joinPoint.getArgs();
+
+		if (activityType.getRequiredTargetId()) {
+			targetId = extractTargetId(args);
+			// if (targetId == null) {
+			// 	targetId =
+			// }
+		}
+
+		String ipAdress = request.getRemoteAddr();
+	}
+
+	private Long extractUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			throw new IllegalStateException("인증된 사용자가 아닙니다.");
+		}
+
+		Object principal = authentication.getPrincipal();
+
+		if (principal instanceof User) {
+			return ((User)principal).getId();
+		}
+		throw new IllegalStateException("알 수 없는 사용자입니다.");
+	}
+
+	private Long extractTargetId(Object[] args) {
+		for (Object arg : args) {
+			if (arg instanceof Long) {
+				Long targetId = (Long)arg;
+				return targetId;
+			}
+		}
+		return null;
+	}
 }

--- a/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLogAspect.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLogAspect.java
@@ -1,5 +1,7 @@
 package com.explorer.gabom.domain.activity.aop;
 
+import java.lang.annotation.Annotation;
+
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
@@ -8,9 +10,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import com.explorer.gabom.domain.activity.entity.ActivityLog;
 import com.explorer.gabom.domain.activity.repository.ActivityLogRepository;
 import com.explorer.gabom.domain.activity.type.ActivityType;
 import com.explorer.gabom.domain.user.entity.User;
+import com.explorer.gabom.global.dto.ApiResponse;
+import com.explorer.gabom.global.dto.TargetIdentifiable;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -35,18 +40,22 @@ public class ActivityLogAspect {
 		ActivityType activityType = activityLoggable.value();
 
 		Long userId = extractUserId();
-		Long targetId = null;
+		Long targetId = activityType.isRequiredTargetId() ?
+						extractTargetId(signature, joinPoint.getArgs(), result) : null;
 
-		Object[] args = joinPoint.getArgs();
+		String ipAddress = request.getRemoteAddr();
+		String description = activityType.getMessage();
 
-		if (activityType.getRequiredTargetId()) {
-			targetId = extractTargetId(args);
-			// if (targetId == null) {
-			// 	targetId =
-			// }
-		}
+		ActivityLog activityLog = new ActivityLog(
+			userId,
+			targetId,
+			activityType,
+			description,
+			ipAddress
+		);
 
-		String ipAdress = request.getRemoteAddr();
+		activityLogRepository.save(activityLog);
+		log.info("활동 로그 저장: {}", activityLog);
 	}
 
 	private Long extractUserId() {
@@ -64,13 +73,25 @@ public class ActivityLogAspect {
 		throw new IllegalStateException("알 수 없는 사용자입니다.");
 	}
 
-	private Long extractTargetId(Object[] args) {
-		for (Object arg : args) {
-			if (arg instanceof Long) {
-				Long targetId = (Long)arg;
-				return targetId;
+	private Long extractTargetId(MethodSignature signature, Object[] args, Object result) {
+		// 1. @TargetId 파라미터 확인
+		Annotation[][] paramAnnotations = signature.getMethod().getParameterAnnotations();
+		for (int i = 0; i < args.length; i++) {
+			for (Annotation annotation : paramAnnotations[i]) {
+				if (annotation instanceof TargetId && args[i] instanceof Long) {
+					return (Long)args[i];
+				}
 			}
 		}
+
+		// 2. ResponseDto에서 TargetIdentifiable 확인
+		if (result instanceof ApiResponse<?> apiResponse) {
+			Object data = apiResponse.getData();
+			if (data instanceof TargetIdentifiable identifiable) {
+				return identifiable.getTargetId();
+			}
+		}
+
 		return null;
 	}
 }

--- a/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLogAspect.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLogAspect.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.activity.aop;public class ActivityLogAspect {
+}

--- a/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLoggable.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLoggable.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.activity.aop;public interface ActivityLoggable {
+}

--- a/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLoggable.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLoggable.java
@@ -1,2 +1,14 @@
-package com.explorer.gabom.domain.activity.aop;public interface ActivityLoggable {
+package com.explorer.gabom.domain.activity.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.explorer.gabom.domain.activity.type.ActivityType;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ActivityLoggable {
+	ActivityType value();
 }

--- a/src/main/java/com/explorer/gabom/domain/activity/aop/TargetId.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/aop/TargetId.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.activity.aop;public interface TargetId {
+}

--- a/src/main/java/com/explorer/gabom/domain/activity/aop/TargetId.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/aop/TargetId.java
@@ -1,2 +1,12 @@
-package com.explorer.gabom.domain.activity.aop;public interface TargetId {
+package com.explorer.gabom.domain.activity.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// targetId로 사용될 컨트롤러 파라미터에 붙이는 어노테이션
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TargetId {
 }

--- a/src/main/java/com/explorer/gabom/domain/activity/entity/ActivityLog.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/entity/ActivityLog.java
@@ -6,24 +6,22 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.explorer.gabom.domain.activity.type.ActivityType;
-import com.explorer.gabom.domain.user.entity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "activity_log")
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class ActivityLog {
 
@@ -32,9 +30,7 @@ public class ActivityLog {
 	private Long id;
 
 	// 활동 주체
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+	private Long userId;
 
 	// 타겟 ID (예: 인증글 ID, 장소 ID 등)
 	private Long targetId;
@@ -53,5 +49,13 @@ public class ActivityLog {
 	@CreatedDate
 	@Column(nullable = false, updatable = false)
 	private LocalDateTime createdAt;
+
+	public ActivityLog(Long userId, Long targetId, ActivityType activityType, String description, String ipAddress) {
+		this.userId = userId;
+		this.targetId = targetId;
+		this.activityType = activityType;
+		this.description = description;
+		this.ipAddress = ipAddress;
+	}
 }
 

--- a/src/main/java/com/explorer/gabom/domain/activity/repository/ActivityLogRepository.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/repository/ActivityLogRepository.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.activity.repository;public interface ActivityLogRepository {
+}

--- a/src/main/java/com/explorer/gabom/domain/activity/repository/ActivityLogRepository.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/repository/ActivityLogRepository.java
@@ -1,2 +1,9 @@
-package com.explorer.gabom.domain.activity.repository;public interface ActivityLogRepository {
+package com.explorer.gabom.domain.activity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.explorer.gabom.domain.activity.entity.ActivityLog;
+
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> {
+	
 }

--- a/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
@@ -1,19 +1,24 @@
 package com.explorer.gabom.domain.activity.type;
 
+import lombok.Getter;
+
+@Getter
 public enum ActivityType {
-	MISSION_PROOF_CREATED(true),
-	PLACE_SHARED(true),
-	QUEST_COMPLETED(true),
-	TITLE_EARNED(true),
-	USER_LOGIN(false);
+	MISSION_PROOF_CREATED(true, "인증글을 작성하였습니다."),
+
+	PLACE_SHARED(true, "장소를 등록하였습니다."),
+
+	QUEST_COMPLETED(true, "퀘스트를 달성하였습니다."),
+
+	TITLE_EARNED(true, "칭호를 획득하였습니다."),
+
+	AUTH_LOGIN(false, "로그인하였습니다.");
 
 	private final boolean requiredTargetId;
+	private final String message;
 
-	ActivityType(boolean requiredTargetId) {
+	ActivityType(boolean requiredTargetId, String message) {
 		this.requiredTargetId = requiredTargetId;
-	}
-
-	public boolean getRequiredTargetId() {
-		return requiredTargetId;
+		this.message = message;
 	}
 }

--- a/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
@@ -1,9 +1,19 @@
 package com.explorer.gabom.domain.activity.type;
 
 public enum ActivityType {
-	MISSION_PROOF_CREATED,
-	PLACE_SHARED,
-	QUEST_COMPLETED,
-	USER_FOLLOWED,
-	TITLE_EARNED
+	MISSION_PROOF_CREATED(true),
+	PLACE_SHARED(true),
+	QUEST_COMPLETED(true),
+	TITLE_EARNED(true),
+	USER_LOGIN(false);
+
+	private final boolean requiredTargetId;
+
+	ActivityType(boolean requiredTargetId) {
+		this.requiredTargetId = requiredTargetId;
+	}
+
+	public boolean getRequiredTargetId() {
+		return requiredTargetId;
+	}
 }

--- a/src/main/java/com/explorer/gabom/global/dto/TargetIdentifiable.java
+++ b/src/main/java/com/explorer/gabom/global/dto/TargetIdentifiable.java
@@ -1,2 +1,5 @@
-package com.explorer.gabom.global.dto;public interface TargetIdentifiable {
+package com.explorer.gabom.global.dto;
+
+public interface TargetIdentifiable {
+	Long getTargetId();
 }

--- a/src/main/java/com/explorer/gabom/global/dto/TargetIdentifiable.java
+++ b/src/main/java/com/explorer/gabom/global/dto/TargetIdentifiable.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.global.dto;public interface TargetIdentifiable {
+}


### PR DESCRIPTION
## 📌 개요
활동 로그 저장 기능 추가

## ✅ 작업 사항
- [x] 활동 시(메서드에 ActivityLoggable어노테이션을 추가하여 확인) 활동 로그를 기록하는 기능 추가
- [x] SecurityContextHolder에서 유저 정보를 추출하여 얻은 userId를 사용.
- [x] 컨트롤러에서 @TargetId어노테이션을 활용하여 targetId를 추출. TargetIdentifiable를 상속받은 responseDto에서 getTargetId메서드를 활용하여 targetId를 추출.
- [x] enum ActivityType에 targetId의 유무, 메세지 속성을 추가 

## 🔍 리뷰 요청 포인트
- targetId를 가져오지 못하는 상황이 있는지 확인 부탁드립니다.

## 💬 기타 사항
- 관련 이슈: #30 

---
