### PR TITLE
fix: 탐험 장소 등록/수정 시 객체 user->userId로 변경

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/explorer/gabom/domain/place/controller/PlaceController.java
@@ -1,7 +1,7 @@
 package com.explorer.gabom.domain.place.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,7 +13,6 @@ import com.explorer.gabom.domain.place.dto.request.PlaceCreateRequest;
 import com.explorer.gabom.domain.place.dto.request.PlaceUpdateRequest;
 import com.explorer.gabom.domain.place.dto.response.PlaceCreateResponse;
 import com.explorer.gabom.domain.place.service.PlaceService;
-import com.explorer.gabom.domain.user.entity.User;
 import com.explorer.gabom.global.dto.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -28,11 +27,15 @@ public class PlaceController {
 	// 탐험 장소 생성
 	@PostMapping
 	public ResponseEntity<ApiResponse<PlaceCreateResponse>> createPlace(
-		@RequestBody PlaceCreateRequest request,
-		@AuthenticationPrincipal User user
+		@RequestBody PlaceCreateRequest request
+		/* TODO : 인증 로직 들어오면 주석해제
+		@AuthenticationPrincipal User user */
 	) {
-		PlaceCreateResponse response = placeService.createPlace(request, user);
-		return ResponseEntity.ok(ApiResponse.success("장소 등록이 완료되었습니다.", response));
+		Long userId = 1L; // TODO: 인증 붙으면 교체
+		PlaceCreateResponse response = placeService.createPlace(request, userId);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+							 .body(ApiResponse.success("장소 등록이 완료되었습니다.", response));
 	}
 
 	// 탐험 장소 리스트 조회(검색)
@@ -43,10 +46,12 @@ public class PlaceController {
 	@PatchMapping("/{placeId}")
 	public ResponseEntity<ApiResponse<Void>> updatePlace(
 		@PathVariable Long placeId,
-		@RequestBody PlaceUpdateRequest request,
-		@AuthenticationPrincipal User user
+		@RequestBody PlaceUpdateRequest request
+		/* TODO : 인증 로직 들어오면 주석해제
+		@AuthenticationPrincipal User user */
 	) {
-		placeService.updatePlace(placeId, request, user);
+		Long userId = 1L; // TODO: 인증 붙으면 교체
+		placeService.updatePlace(placeId, request, userId);
 		return ResponseEntity.ok(ApiResponse.success("장소가 수정되었습니다."));
 	}
 

--- a/src/main/java/com/explorer/gabom/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/explorer/gabom/domain/place/controller/PlaceController.java
@@ -15,6 +15,7 @@ import com.explorer.gabom.domain.place.dto.response.PlaceCreateResponse;
 import com.explorer.gabom.domain.place.service.PlaceService;
 import com.explorer.gabom.global.dto.ApiResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -27,7 +28,7 @@ public class PlaceController {
 	// 탐험 장소 생성
 	@PostMapping
 	public ResponseEntity<ApiResponse<PlaceCreateResponse>> createPlace(
-		@RequestBody PlaceCreateRequest request
+		@RequestBody @Valid PlaceCreateRequest request
 		/* TODO : 인증 로직 들어오면 주석해제
 		@AuthenticationPrincipal User user */
 	) {

--- a/src/main/java/com/explorer/gabom/domain/place/dto/request/PlaceCreateRequest.java
+++ b/src/main/java/com/explorer/gabom/domain/place/dto/request/PlaceCreateRequest.java
@@ -1,5 +1,7 @@
 package com.explorer.gabom.domain.place.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,10 +9,21 @@ import lombok.Getter;
 @AllArgsConstructor
 public class PlaceCreateRequest {
 
+	@NotBlank(message = "제목은 필수입니다.")
 	private final String title;
+
+	@NotBlank(message = "주소는 필수입니다.")
 	private final String address;
+
+	@NotNull(message = "위도 값은 필수입니다.")
 	private final Double lat;
+
+	@NotNull(message = "경도 값은 필수입니다.")
 	private final Double lng;
+
+	@NotBlank(message = "인증 방법은 필수입니다.")
 	private final String proofMethod;
+
+	@NotBlank(message = "본문은 필수입니다.")
 	private final String content;
 }

--- a/src/main/java/com/explorer/gabom/domain/place/entity/Place.java
+++ b/src/main/java/com/explorer/gabom/domain/place/entity/Place.java
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(name = "places")
-@SQLDelete(sql = "UPDATE place SET deleted_at = NOW() WHERE id = ?")
+@SQLDelete(sql = "UPDATE places SET deleted_at = NOW() WHERE id = ?")
 public class Place extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/explorer/gabom/domain/place/entity/Place.java
+++ b/src/main/java/com/explorer/gabom/domain/place/entity/Place.java
@@ -28,8 +28,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "places")
-@SQLDelete(sql = "UPDATE places SET deleted_at = NOW() WHERE id = ?")
+@Table(name = "place")
+@SQLDelete(sql = "UPDATE place SET deleted_at = NOW() WHERE id = ?")
 public class Place extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/explorer/gabom/domain/place/service/PlaceService.java
+++ b/src/main/java/com/explorer/gabom/domain/place/service/PlaceService.java
@@ -9,6 +9,7 @@ import com.explorer.gabom.domain.place.dto.response.PlaceCreateResponse;
 import com.explorer.gabom.domain.place.entity.Place;
 import com.explorer.gabom.domain.place.repository.PlaceRepository;
 import com.explorer.gabom.domain.user.entity.User;
+import com.explorer.gabom.domain.user.repository.UserRepository;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
 
@@ -19,12 +20,14 @@ import lombok.RequiredArgsConstructor;
 public class PlaceService {
 
 	private final PlaceRepository placeRepository;
+	private final UserRepository userRepository;
 
 	// 탐험 장소 생성
-	public PlaceCreateResponse createPlace(PlaceCreateRequest request, User user) {
+	public PlaceCreateResponse createPlace(PlaceCreateRequest request, Long userId) {
+		User user = userRepository.findById(userId)
+								  .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		Place place = new Place(request, user);
-
 		Place savedPlace = placeRepository.save(place);
 
 		return new PlaceCreateResponse(savedPlace.getId());
@@ -36,12 +39,12 @@ public class PlaceService {
 
 	// 탐험 장소 수정
 	@Transactional
-	public void updatePlace(Long placeId, PlaceUpdateRequest request, User user) {
+	public void updatePlace(Long placeId, PlaceUpdateRequest request, Long userId) {
 		Place place = placeRepository.findById(placeId)
 									 .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
 
 		// 작성자 확인
-		if (!place.getUser().getId().equals(user.getId())) {
+		if (!place.getUser().getId().equals(userId)) {
 			throw new CustomException(ErrorCode.PLACE_NO_PERMISSION);
 		}
 


### PR DESCRIPTION
#95

## 📌 개요
- Place 생성 및 수정 시 User 객체 대신 userId를 파라미터로 사용하도록 변경.
- 인증(JWT) 연동 전 임시로 userId를 서비스에서 직접 받아 처리

## ✅ 작업 사항
- [ ] PlaceService의 createPlace, updatePlace 메서드 시그니처를 userId 기반으로 변경
- [ ] PlaceController에서 @AuthenticationPrincipal 대신 userId 하드코딩 (추후 JWT로 교체 예정)
- [ ] PlaceService 내부에서 userRepository.findById(userId)로 User 객체 조회 로직 추가

## 🔍 리뷰 요청 포인트

## 💬 기타 사항
- 관련 이슈: #95

---
