### PR TITLE
Feat: 퀘스트 수정 기능 추가

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
@@ -13,7 +13,8 @@ public enum ActivityType {
 	AUTH_LOGIN(false, "로그인하였습니다."),
 
 	// 관리자 활동
-	ADMIN_QUEST_CREATED(true, "퀘스트를 등록하였습니다.");
+	ADMIN_QUEST_CREATED(true, "퀘스트를 등록하였습니다."),
+	ADMIN_QUEST_UPDATED(true, "퀘스트를 수정하였습니다.");
 
 	private final boolean requiredTargetId;
 	private final String message;

--- a/src/main/java/com/explorer/gabom/domain/quest/controller/QuestController.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/controller/QuestController.java
@@ -1,13 +1,18 @@
 package com.explorer.gabom.domain.quest.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
+import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
+import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
 import com.explorer.gabom.domain.quest.service.QuestService;
 import com.explorer.gabom.global.dto.ApiResponse;
 
@@ -15,17 +20,26 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/admin/quests")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class QuestController {
 
 	private final QuestService questService;
 
-	@PostMapping
+	@PostMapping("/admin/quests")
 	public ResponseEntity<ApiResponse<QuestCreateResponseDto>> createQuest(
 		@Valid @RequestBody QuestCreateRequestDto request) {
 
 		QuestCreateResponseDto response = questService.createQuest(request);
-		return ResponseEntity.ok(ApiResponse.success("퀘스트가 성공적으로 등록되었습니다.", response));
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("퀘스트가 성공적으로 등록되었습니다.", response));
+	}
+
+	@PatchMapping("admin/quests/{questId}")
+	public ResponseEntity<ApiResponse<QuestUpdateResponseDto>> updateQuest(
+		@PathVariable Long questId,
+		@Valid @RequestBody QuestUpdateRequestDto request) {
+
+		QuestUpdateResponseDto response = questService.updateQuest(questId, request);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("퀘스트가 성공적으로 수정되었습니다.", response));
 	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/request/QuestUpdateRequestDto.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/request/QuestUpdateRequestDto.java
@@ -1,0 +1,4 @@
+package com.explorer.gabom.domain.quest.dto.request;
+
+public class QuestUpdateRequestDto {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/request/QuestUpdateRequestDto.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/request/QuestUpdateRequestDto.java
@@ -1,4 +1,25 @@
 package com.explorer.gabom.domain.quest.dto.request;
 
+import com.explorer.gabom.domain.quest.type.QuestConditionType;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class QuestUpdateRequestDto {
+
+	private String title;
+
+	private String description;
+
+	private QuestConditionType questConditionType;
+
+	private Integer acquireCondition;
+
+	private Integer rewardPoint;
+
+	private Integer rewardExp;
+
+	private Long rewardTitleId;
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestUpdateResponseDto.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestUpdateResponseDto.java
@@ -1,2 +1,44 @@
-package com.explorer.gabom.domain.quest.dto.response;public class QuestUpdateResponseDto {
+package com.explorer.gabom.domain.quest.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.explorer.gabom.domain.quest.entity.Quest;
+import com.explorer.gabom.domain.quest.type.QuestConditionType;
+import com.explorer.gabom.global.dto.TargetIdentifiable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestUpdateResponseDto implements TargetIdentifiable {
+
+	private Long questId;
+	private String title;
+	private String description;
+	private QuestConditionType questConditionType;
+	private int acquireCondition;
+	private int rewardPoint;
+	private int rewardExp;
+	private Long rewardTitleId;
+	private LocalDateTime updatedAt;
+
+	public static QuestUpdateResponseDto toDto(Quest quest) {
+		return QuestUpdateResponseDto.builder()
+									 .questId(quest.getId())
+									 .title(quest.getTitle())
+									 .description(quest.getDescription())
+									 .questConditionType(quest.getQuestConditionType())
+									 .acquireCondition(quest.getAcquireCondition())
+									 .rewardPoint(quest.getRewardPoint())
+									 .rewardExp(quest.getRewardExp())
+									 .rewardTitleId(quest.getRewardTitle().getId())
+									 .updatedAt(quest.getUpdatedAt())
+									 .build();
+	}
+
+	@Override
+	public Long getTargetId() {
+		return this.questId;
+	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestUpdateResponseDto.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestUpdateResponseDto.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.quest.dto.response;public class QuestUpdateResponseDto {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/entity/Quest.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/entity/Quest.java
@@ -1,5 +1,6 @@
 package com.explorer.gabom.domain.quest.entity;
 
+import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
 import com.explorer.gabom.domain.quest.type.QuestConditionType;
 import com.explorer.gabom.domain.title.entity.Title;
 import com.explorer.gabom.global.entity.BaseTimeEntity;
@@ -58,5 +59,22 @@ public class Quest extends BaseTimeEntity {
 		this.rewardPoint = rewardPoint;
 		this.rewardExp = rewardExp;
 		this.rewardTitle = rewardTitle;
+	}
+
+	public void update(QuestUpdateRequestDto dto, Title rewardTitle) {
+		if (dto.getTitle() != null)
+			this.title = dto.getTitle();
+		if (dto.getDescription() != null)
+			this.description = dto.getDescription();
+		if (dto.getQuestConditionType() != null)
+			this.questConditionType = dto.getQuestConditionType();
+		if (dto.getAcquireCondition() != null)
+			this.acquireCondition = dto.getAcquireCondition();
+		if (dto.getRewardPoint() != null)
+			this.rewardPoint = dto.getRewardPoint();
+		if (dto.getRewardExp() != null)
+			this.rewardExp = dto.getRewardExp();
+		if (rewardTitle != null)
+			this.rewardTitle = rewardTitle;
 	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/service/QuestService.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/QuestService.java
@@ -1,8 +1,12 @@
 package com.explorer.gabom.domain.quest.service;
 
 import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
+import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
+import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
 
 public interface QuestService {
 	QuestCreateResponseDto createQuest(QuestCreateRequestDto dto);
+
+	QuestUpdateResponseDto updateQuest(Long questId, QuestUpdateRequestDto dto);
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/service/QuestServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/QuestServiceImpl.java
@@ -5,7 +5,9 @@ import org.springframework.stereotype.Service;
 import com.explorer.gabom.domain.activity.aop.ActivityLoggable;
 import com.explorer.gabom.domain.activity.type.ActivityType;
 import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
+import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
+import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
 import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.repository.QuestRepository;
 import com.explorer.gabom.domain.title.entity.Title;
@@ -43,4 +45,22 @@ public class QuestServiceImpl implements QuestService {
 		Quest saved = questRepository.save(quest);
 		return QuestCreateResponseDto.toDto(saved);
 	}
+
+	@Override
+	@Transactional
+	@ActivityLoggable(ActivityType.ADMIN_QUEST_UPDATED)
+	public QuestUpdateResponseDto updateQuest(Long questId, QuestUpdateRequestDto dto) {
+		Quest quest = questRepository.findById(questId)
+									 .orElseThrow(() -> new CustomException(ErrorCode.QUEST_NOT_FOUND));
+
+		Title rewardTitle = null;
+		if (dto.getRewardTitleId() != null) {
+			rewardTitle = titleRepository.findById(dto.getRewardTitleId())
+										 .orElseThrow(() -> new CustomException(ErrorCode.TITLE_NOT_FOUND));
+		}
+
+		quest.update(dto, rewardTitle);
+		return QuestUpdateResponseDto.toDto(quest);
+	}
+
 }

--- a/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
+++ b/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
@@ -28,7 +28,10 @@ public enum ErrorCode {
 	PLACE_NO_PERMISSION(HttpStatus.FORBIDDEN, "해당 장소에 대한 권한이 없습니다."),
 
 	// Title
-	TITLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 칭호를 찾을 수 없습니다.");
+	TITLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 칭호를 찾을 수 없습니다."),
+
+	// Quest
+	QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 퀘스트를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
+++ b/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
@@ -17,16 +17,16 @@ public enum ErrorCode {
 
 	// Auth
 	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 이메일입니다."),
-  
+
 	NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 닉네임입니다."),
 
-	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다.");
-  
+	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
+
 	// Place
 	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 장소를 찾을 수 없습니다."),
 
 	PLACE_NO_PERMISSION(HttpStatus.FORBIDDEN, "해당 장소에 대한 권한이 없습니다."),
-  
+
 	// Title
 	TITLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 칭호를 찾을 수 없습니다.");
 


### PR DESCRIPTION
## 📌 개요
퀘스트 수정 기능 추가

## ✅ 작업 사항
- [x] 퀘스트 수정(ADMIN_QUEST_UPDATED) 활동 로그 추가.
- [x] 퀘스트 수정 api 구현
- [x] 퀘스트 수정 시 활동 로그 자동 저장. targetId는 QuestUpdateResponseDto에서 getTargetId를 사용하여 추출.
- [x] QuestUpdateRequestDto에서 null이 아닌 값만 업데이트 진행.

## 🔍 리뷰 요청 포인트
- 구현 내용이 api 명세서와 같은지 확인 부탁드립니다.

## 💬 기타 사항
- 관련 이슈: #55 

---
