### PR TITLE
Feat: 퀘스트 삭제 기능 추가

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLogAspect.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/aop/ActivityLogAspect.java
@@ -16,6 +16,7 @@ import com.explorer.gabom.domain.activity.repository.AdminActivityLogRepository;
 import com.explorer.gabom.domain.activity.repository.UserActivityLogRepository;
 import com.explorer.gabom.domain.activity.type.ActivityType;
 import com.explorer.gabom.domain.user.entity.User;
+import com.explorer.gabom.domain.user.type.UserRole;
 import com.explorer.gabom.global.dto.ApiResponse;
 import com.explorer.gabom.global.dto.TargetIdentifiable;
 
@@ -42,14 +43,17 @@ public class ActivityLogAspect {
 		ActivityLoggable activityLoggable = signature.getMethod().getAnnotation(ActivityLoggable.class);
 		ActivityType activityType = activityLoggable.value();
 
-		Long userId = extractUserId();
+		User currentUser = extractUser();
+		Long userId = currentUser.getId();
+		UserRole userRole = currentUser.getUserRole();
+
 		Long targetId = activityType.isRequiredTargetId() ?
 						extractTargetId(signature, joinPoint.getArgs(), result) : null;
 
 		String ipAddress = request.getRemoteAddr();
 		String description = activityType.getMessage();
 
-		if (activityType.isAdminActivity()) {
+		if (userRole == UserRole.ADMIN) {
 			AdminActivityLog adminActivityLog = new AdminActivityLog(userId, targetId, activityType, description,
 																	 ipAddress);
 			adminActivityLogRepository.save(adminActivityLog);
@@ -62,14 +66,14 @@ public class ActivityLogAspect {
 		}
 	}
 
-	private Long extractUserId() {
+	private User extractUser() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		if (authentication == null || !authentication.isAuthenticated()) {
 			throw new IllegalStateException("인증된 사용자가 아닙니다.");
 		}
 		Object principal = authentication.getPrincipal();
-		if (principal instanceof User) {
-			return ((User)principal).getId();
+		if (principal instanceof User user) {
+			return user;
 		}
 		throw new IllegalStateException("알 수 없는 사용자입니다.");
 	}

--- a/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
@@ -14,7 +14,8 @@ public enum ActivityType {
 
 	// 관리자 활동
 	ADMIN_QUEST_CREATED(true, "퀘스트를 등록하였습니다."),
-	ADMIN_QUEST_UPDATED(true, "퀘스트를 수정하였습니다.");
+	ADMIN_QUEST_UPDATED(true, "퀘스트를 수정하였습니다."),
+	ADMIN_QUEST_DELETED(true, "퀘스트를 삭제하였습니다.");
 
 	private final boolean requiredTargetId;
 	private final String message;

--- a/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
+++ b/src/main/java/com/explorer/gabom/domain/activity/type/ActivityType.java
@@ -25,7 +25,4 @@ public enum ActivityType {
 		this.message = message;
 	}
 
-	public boolean isAdminActivity() {
-		return this.name().startsWith("ADMIN_");
-	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/controller/QuestController.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/controller/QuestController.java
@@ -10,11 +10,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
-import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponseDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
+import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequest;
+import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequest;
+import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponse;
+import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponse;
+import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponse;
 import com.explorer.gabom.domain.quest.service.QuestService;
 import com.explorer.gabom.global.dto.ApiResponse;
 
@@ -29,28 +29,28 @@ public class QuestController {
 	private final QuestService questService;
 
 	@PostMapping("/admin/quests")
-	public ResponseEntity<ApiResponse<QuestCreateResponseDto>> createQuest(
-		@Valid @RequestBody QuestCreateRequestDto request) {
+	public ResponseEntity<ApiResponse<QuestCreateResponse>> createQuest(
+		@Valid @RequestBody QuestCreateRequest request) {
 
-		QuestCreateResponseDto response = questService.createQuest(request);
+		QuestCreateResponse response = questService.createQuest(request);
 		return ResponseEntity.status(HttpStatus.CREATED)
 							 .body(ApiResponse.success("퀘스트가 성공적으로 등록되었습니다.", response));
 	}
 
 	@PatchMapping("admin/quests/{questId}")
-	public ResponseEntity<ApiResponse<QuestUpdateResponseDto>> updateQuest(
+	public ResponseEntity<ApiResponse<QuestUpdateResponse>> updateQuest(
 		@PathVariable Long questId,
-		@Valid @RequestBody QuestUpdateRequestDto request) {
+		@Valid @RequestBody QuestUpdateRequest request) {
 
-		QuestUpdateResponseDto response = questService.updateQuest(questId, request);
+		QuestUpdateResponse response = questService.updateQuest(questId, request);
 		return ResponseEntity.status(HttpStatus.OK)
 							 .body(ApiResponse.success("퀘스트가 성공적으로 수정되었습니다.", response));
 	}
 
 	@DeleteMapping("/admin/quests/{questId}")
-	public ResponseEntity<ApiResponse<QuestDeleteResponseDto>> deleteQuest(@PathVariable Long questId) {
+	public ResponseEntity<ApiResponse<QuestDeleteResponse>> deleteQuest(@PathVariable Long questId) {
 
-		QuestDeleteResponseDto response = questService.deleteQuest(questId);
+		QuestDeleteResponse response = questService.deleteQuest(questId);
 		return ResponseEntity.status(HttpStatus.OK)
 							 .body(ApiResponse.success("퀘스트가 삭제되었습니다.", response));
 	}

--- a/src/main/java/com/explorer/gabom/domain/quest/controller/QuestController.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/controller/QuestController.java
@@ -2,6 +2,7 @@ package com.explorer.gabom.domain.quest.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
 import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
+import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponseDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
 import com.explorer.gabom.domain.quest.service.QuestService;
 import com.explorer.gabom.global.dto.ApiResponse;
@@ -31,7 +33,8 @@ public class QuestController {
 		@Valid @RequestBody QuestCreateRequestDto request) {
 
 		QuestCreateResponseDto response = questService.createQuest(request);
-		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("퀘스트가 성공적으로 등록되었습니다.", response));
+		return ResponseEntity.status(HttpStatus.CREATED)
+							 .body(ApiResponse.success("퀘스트가 성공적으로 등록되었습니다.", response));
 	}
 
 	@PatchMapping("admin/quests/{questId}")
@@ -40,6 +43,15 @@ public class QuestController {
 		@Valid @RequestBody QuestUpdateRequestDto request) {
 
 		QuestUpdateResponseDto response = questService.updateQuest(questId, request);
-		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("퀘스트가 성공적으로 수정되었습니다.", response));
+		return ResponseEntity.status(HttpStatus.OK)
+							 .body(ApiResponse.success("퀘스트가 성공적으로 수정되었습니다.", response));
+	}
+
+	@DeleteMapping("/admin/quests/{questId}")
+	public ResponseEntity<ApiResponse<QuestDeleteResponseDto>> deleteQuest(@PathVariable Long questId) {
+
+		QuestDeleteResponseDto response = questService.deleteQuest(questId);
+		return ResponseEntity.status(HttpStatus.OK)
+							 .body(ApiResponse.success("퀘스트가 삭제되었습니다.", response));
 	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/request/QuestCreateRequest.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/request/QuestCreateRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class QuestCreateRequestDto {
+public class QuestCreateRequest {
 
 	@NotBlank(message = "제목은 필수입니다.")
 	private String title;

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/request/QuestUpdateRequest.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/request/QuestUpdateRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class QuestUpdateRequestDto {
+public class QuestUpdateRequest {
 
 	private String title;
 

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestCreateResponse.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestCreateResponse.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class QuestCreateResponseDto implements TargetIdentifiable {
+public class QuestCreateResponse implements TargetIdentifiable {
 	private Long questId;
 	private String title;
 	private String description;
@@ -22,18 +22,18 @@ public class QuestCreateResponseDto implements TargetIdentifiable {
 	private Long rewardTitleId;
 	private LocalDateTime createdAt;
 
-	public static QuestCreateResponseDto toDto(Quest quest) {
-		return QuestCreateResponseDto.builder()
-									 .questId(quest.getId())
-									 .title(quest.getTitle())
-									 .description(quest.getDescription())
-									 .questConditionType(quest.getQuestConditionType())
-									 .acquireCondition(quest.getAcquireCondition())
-									 .rewardPoint(quest.getRewardPoint())
-									 .rewardExp(quest.getRewardExp())
-									 .rewardTitleId(quest.getRewardTitle().getId())
-									 .createdAt(quest.getCreatedAt())
-									 .build();
+	public static QuestCreateResponse toDto(Quest quest) {
+		return QuestCreateResponse.builder()
+								  .questId(quest.getId())
+								  .title(quest.getTitle())
+								  .description(quest.getDescription())
+								  .questConditionType(quest.getQuestConditionType())
+								  .acquireCondition(quest.getAcquireCondition())
+								  .rewardPoint(quest.getRewardPoint())
+								  .rewardExp(quest.getRewardExp())
+								  .rewardTitleId(quest.getRewardTitle().getId())
+								  .createdAt(quest.getCreatedAt())
+								  .build();
 	}
 
 	@Override

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestDeleteResponse.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestDeleteResponse.java
@@ -9,16 +9,16 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class QuestDeleteResponseDto implements TargetIdentifiable {
+public class QuestDeleteResponse implements TargetIdentifiable {
 
 	private Long questId;
 	private LocalDateTime deletedAt;
 
-	public static QuestDeleteResponseDto fromId(Long questId) {
-		return QuestDeleteResponseDto.builder()
-									 .questId(questId)
-									 .deletedAt(LocalDateTime.now())
-									 .build();
+	public static QuestDeleteResponse fromId(Long questId) {
+		return QuestDeleteResponse.builder()
+								  .questId(questId)
+								  .deletedAt(LocalDateTime.now())
+								  .build();
 	}
 
 	@Override

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestDeleteResponseDto.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestDeleteResponseDto.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.quest.dto.response;public class QuestDeleteResponseDto {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestDeleteResponseDto.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestDeleteResponseDto.java
@@ -1,2 +1,28 @@
-package com.explorer.gabom.domain.quest.dto.response;public class QuestDeleteResponseDto {
+package com.explorer.gabom.domain.quest.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.explorer.gabom.global.dto.TargetIdentifiable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestDeleteResponseDto implements TargetIdentifiable {
+
+	private Long questId;
+	private LocalDateTime deletedAt;
+
+	public static QuestDeleteResponseDto fromId(Long questId) {
+		return QuestDeleteResponseDto.builder()
+									 .questId(questId)
+									 .deletedAt(LocalDateTime.now())
+									 .build();
+	}
+
+	@Override
+	public Long getTargetId() {
+		return this.questId;
+	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestUpdateResponse.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/response/QuestUpdateResponse.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class QuestUpdateResponseDto implements TargetIdentifiable {
+public class QuestUpdateResponse implements TargetIdentifiable {
 
 	private Long questId;
 	private String title;
@@ -23,18 +23,18 @@ public class QuestUpdateResponseDto implements TargetIdentifiable {
 	private Long rewardTitleId;
 	private LocalDateTime updatedAt;
 
-	public static QuestUpdateResponseDto toDto(Quest quest) {
-		return QuestUpdateResponseDto.builder()
-									 .questId(quest.getId())
-									 .title(quest.getTitle())
-									 .description(quest.getDescription())
-									 .questConditionType(quest.getQuestConditionType())
-									 .acquireCondition(quest.getAcquireCondition())
-									 .rewardPoint(quest.getRewardPoint())
-									 .rewardExp(quest.getRewardExp())
-									 .rewardTitleId(quest.getRewardTitle().getId())
-									 .updatedAt(quest.getUpdatedAt())
-									 .build();
+	public static QuestUpdateResponse toDto(Quest quest) {
+		return QuestUpdateResponse.builder()
+								  .questId(quest.getId())
+								  .title(quest.getTitle())
+								  .description(quest.getDescription())
+								  .questConditionType(quest.getQuestConditionType())
+								  .acquireCondition(quest.getAcquireCondition())
+								  .rewardPoint(quest.getRewardPoint())
+								  .rewardExp(quest.getRewardExp())
+								  .rewardTitleId(quest.getRewardTitle().getId())
+								  .updatedAt(quest.getUpdatedAt())
+								  .build();
 	}
 
 	@Override

--- a/src/main/java/com/explorer/gabom/domain/quest/entity/Quest.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/entity/Quest.java
@@ -1,6 +1,6 @@
 package com.explorer.gabom.domain.quest.entity;
 
-import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
+import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequest;
 import com.explorer.gabom.domain.quest.type.QuestConditionType;
 import com.explorer.gabom.domain.title.entity.Title;
 import com.explorer.gabom.global.entity.BaseTimeEntity;
@@ -61,7 +61,7 @@ public class Quest extends BaseTimeEntity {
 		this.rewardTitle = rewardTitle;
 	}
 
-	public void update(QuestUpdateRequestDto dto, Title rewardTitle) {
+	public void update(QuestUpdateRequest dto, Title rewardTitle) {
 		if (dto.getTitle() != null)
 			this.title = dto.getTitle();
 		if (dto.getDescription() != null)

--- a/src/main/java/com/explorer/gabom/domain/quest/service/QuestService.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/QuestService.java
@@ -3,10 +3,13 @@ package com.explorer.gabom.domain.quest.service;
 import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
 import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
+import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponseDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
 
 public interface QuestService {
 	QuestCreateResponseDto createQuest(QuestCreateRequestDto dto);
 
 	QuestUpdateResponseDto updateQuest(Long questId, QuestUpdateRequestDto dto);
+
+	QuestDeleteResponseDto deleteQuest(Long questId);
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/service/QuestService.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/QuestService.java
@@ -1,15 +1,15 @@
 package com.explorer.gabom.domain.quest.service;
 
-import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
-import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponseDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
+import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequest;
+import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequest;
+import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponse;
+import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponse;
+import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponse;
 
 public interface QuestService {
-	QuestCreateResponseDto createQuest(QuestCreateRequestDto dto);
+	QuestCreateResponse createQuest(QuestCreateRequest dto);
 
-	QuestUpdateResponseDto updateQuest(Long questId, QuestUpdateRequestDto dto);
+	QuestUpdateResponse updateQuest(Long questId, QuestUpdateRequest dto);
 
-	QuestDeleteResponseDto deleteQuest(Long questId);
+	QuestDeleteResponse deleteQuest(Long questId);
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/service/QuestServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/QuestServiceImpl.java
@@ -4,11 +4,11 @@ import org.springframework.stereotype.Service;
 
 import com.explorer.gabom.domain.activity.aop.ActivityLoggable;
 import com.explorer.gabom.domain.activity.type.ActivityType;
-import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
-import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponseDto;
-import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
+import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequest;
+import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequest;
+import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponse;
+import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponse;
+import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponse;
 import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.repository.QuestRepository;
 import com.explorer.gabom.domain.title.entity.Title;
@@ -31,7 +31,7 @@ public class QuestServiceImpl implements QuestService {
 	@Override
 	@Transactional
 	@ActivityLoggable(ActivityType.ADMIN_QUEST_CREATED)
-	public QuestCreateResponseDto createQuest(QuestCreateRequestDto dto) {
+	public QuestCreateResponse createQuest(QuestCreateRequest dto) {
 		Title rewardTitle = titleRepository.findById(dto.getRewardTitleId())
 										   .orElseThrow(() -> new CustomException(ErrorCode.TITLE_NOT_FOUND));
 
@@ -46,13 +46,13 @@ public class QuestServiceImpl implements QuestService {
 		);
 
 		Quest saved = questRepository.save(quest);
-		return QuestCreateResponseDto.toDto(saved);
+		return QuestCreateResponse.toDto(saved);
 	}
 
 	@Override
 	@Transactional
 	@ActivityLoggable(ActivityType.ADMIN_QUEST_UPDATED)
-	public QuestUpdateResponseDto updateQuest(Long questId, QuestUpdateRequestDto dto) {
+	public QuestUpdateResponse updateQuest(Long questId, QuestUpdateRequest dto) {
 		Quest quest = questRepository.findById(questId)
 									 .orElseThrow(() -> new CustomException(ErrorCode.QUEST_NOT_FOUND));
 
@@ -63,18 +63,18 @@ public class QuestServiceImpl implements QuestService {
 		}
 
 		quest.update(dto, rewardTitle);
-		return QuestUpdateResponseDto.toDto(quest);
+		return QuestUpdateResponse.toDto(quest);
 	}
 
 	@Override
 	@Transactional
 	@ActivityLoggable(ActivityType.ADMIN_QUEST_DELETED)
-	public QuestDeleteResponseDto deleteQuest(Long questId) {
+	public QuestDeleteResponse deleteQuest(Long questId) {
 		Quest quest = questRepository.findById(questId)
 									 .orElseThrow(() -> new CustomException(ErrorCode.QUEST_NOT_FOUND));
 
 		questRepository.delete(quest);
-		return QuestDeleteResponseDto.fromId(questId);
+		return QuestDeleteResponse.fromId(questId);
 	}
 
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/service/QuestServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/QuestServiceImpl.java
@@ -7,6 +7,7 @@ import com.explorer.gabom.domain.activity.type.ActivityType;
 import com.explorer.gabom.domain.quest.dto.request.QuestCreateRequestDto;
 import com.explorer.gabom.domain.quest.dto.request.QuestUpdateRequestDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponseDto;
+import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponseDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponseDto;
 import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.repository.QuestRepository;
@@ -17,7 +18,9 @@ import com.explorer.gabom.global.exception.ErrorCode;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class QuestServiceImpl implements QuestService {
@@ -61,6 +64,17 @@ public class QuestServiceImpl implements QuestService {
 
 		quest.update(dto, rewardTitle);
 		return QuestUpdateResponseDto.toDto(quest);
+	}
+
+	@Override
+	@Transactional
+	@ActivityLoggable(ActivityType.ADMIN_QUEST_DELETED)
+	public QuestDeleteResponseDto deleteQuest(Long questId) {
+		Quest quest = questRepository.findById(questId)
+									 .orElseThrow(() -> new CustomException(ErrorCode.QUEST_NOT_FOUND));
+
+		questRepository.delete(quest);
+		return QuestDeleteResponseDto.fromId(questId);
 	}
 
 }


### PR DESCRIPTION
## 📌 개요
퀘스트 삭제 기능 추가

## ✅ 작업 사항
- [x] 퀘스트 삭제(ADMIN_QUEST_DELETED) 활동 로그 추가.
- [x] 퀘스트 삭제 api 구현
- [x] 퀘스트 삭제 시 활동 로그 자동 저장. targetId는 QuestDeleteResponseDto에서 getTargetId를 사용하여 추출.

## 🔍 리뷰 요청 포인트
- 구현 내용이 api 명세서와 같은지 확인 부탁드립니다.

## 💬 기타 사항
- 관련 이슈: #58 

---
