### PR TITLE
feat: 탐험 장소 수정 QueryDSL 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,18 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
 //    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/generated/com/explorer/gabom/domain/activity/entity/QAdminActivityLog.java
+++ b/src/main/generated/com/explorer/gabom/domain/activity/entity/QAdminActivityLog.java
@@ -1,0 +1,49 @@
+package com.explorer.gabom.domain.activity.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAdminActivityLog is a Querydsl query type for AdminActivityLog
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAdminActivityLog extends EntityPathBase<AdminActivityLog> {
+
+    private static final long serialVersionUID = -634144750L;
+
+    public static final QAdminActivityLog adminActivityLog = new QAdminActivityLog("adminActivityLog");
+
+    public final EnumPath<com.explorer.gabom.domain.activity.type.ActivityType> activityType = createEnum("activityType", com.explorer.gabom.domain.activity.type.ActivityType.class);
+
+    public final NumberPath<Long> adminId = createNumber("adminId", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath ipAddress = createString("ipAddress");
+
+    public final NumberPath<Long> targetId = createNumber("targetId", Long.class);
+
+    public QAdminActivityLog(String variable) {
+        super(AdminActivityLog.class, forVariable(variable));
+    }
+
+    public QAdminActivityLog(Path<? extends AdminActivityLog> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAdminActivityLog(PathMetadata metadata) {
+        super(AdminActivityLog.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/activity/entity/QUserActivityLog.java
+++ b/src/main/generated/com/explorer/gabom/domain/activity/entity/QUserActivityLog.java
@@ -1,0 +1,49 @@
+package com.explorer.gabom.domain.activity.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUserActivityLog is a Querydsl query type for UserActivityLog
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUserActivityLog extends EntityPathBase<UserActivityLog> {
+
+    private static final long serialVersionUID = -138046914L;
+
+    public static final QUserActivityLog userActivityLog = new QUserActivityLog("userActivityLog");
+
+    public final EnumPath<com.explorer.gabom.domain.activity.type.ActivityType> activityType = createEnum("activityType", com.explorer.gabom.domain.activity.type.ActivityType.class);
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath ipAddress = createString("ipAddress");
+
+    public final NumberPath<Long> targetId = createNumber("targetId", Long.class);
+
+    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+
+    public QUserActivityLog(String variable) {
+        super(UserActivityLog.class, forVariable(variable));
+    }
+
+    public QUserActivityLog(Path<? extends UserActivityLog> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUserActivityLog(PathMetadata metadata) {
+        super(UserActivityLog.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/missionproof/entity/QMissionProof.java
+++ b/src/main/generated/com/explorer/gabom/domain/missionproof/entity/QMissionProof.java
@@ -1,0 +1,69 @@
+package com.explorer.gabom.domain.missionproof.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMissionProof is a Querydsl query type for MissionProof
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMissionProof extends EntityPathBase<MissionProof> {
+
+    private static final long serialVersionUID = -1587592211L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMissionProof missionProof = new QMissionProof("missionProof");
+
+    public final com.explorer.gabom.global.entity.QBaseTimeEntity _super = new com.explorer.gabom.global.entity.QBaseTimeEntity(this);
+
+    public final com.explorer.gabom.global.file.entity.QAttachmentFile attachmentImg;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.explorer.gabom.domain.place.entity.QPlace place;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QMissionProof(String variable) {
+        this(MissionProof.class, forVariable(variable), INITS);
+    }
+
+    public QMissionProof(Path<? extends MissionProof> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMissionProof(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMissionProof(PathMetadata metadata, PathInits inits) {
+        this(MissionProof.class, metadata, inits);
+    }
+
+    public QMissionProof(Class<? extends MissionProof> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.attachmentImg = inits.isInitialized("attachmentImg") ? new com.explorer.gabom.global.file.entity.QAttachmentFile(forProperty("attachmentImg")) : null;
+        this.place = inits.isInitialized("place") ? new com.explorer.gabom.domain.place.entity.QPlace(forProperty("place"), inits.get("place")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/place/entity/QPlace.java
+++ b/src/main/generated/com/explorer/gabom/domain/place/entity/QPlace.java
@@ -1,0 +1,78 @@
+package com.explorer.gabom.domain.place.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPlace is a Querydsl query type for Place
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPlace extends EntityPathBase<Place> {
+
+    private static final long serialVersionUID = 1635475683L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPlace place = new QPlace("place");
+
+    public final com.explorer.gabom.global.entity.QBaseTimeEntity _super = new com.explorer.gabom.global.entity.QBaseTimeEntity(this);
+
+    public final StringPath address = createString("address");
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final ListPath<PlaceFile, QPlaceFile> files = this.<PlaceFile, QPlaceFile>createList("files", PlaceFile.class, QPlaceFile.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Double> lat = createNumber("lat", Double.class);
+
+    public final NumberPath<Double> lng = createNumber("lng", Double.class);
+
+    public final StringPath proofMethod = createString("proofMethod");
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final com.explorer.gabom.domain.user.entity.QUser user;
+
+    public final NumberPath<Integer> viewCount = createNumber("viewCount", Integer.class);
+
+    public QPlace(String variable) {
+        this(Place.class, forVariable(variable), INITS);
+    }
+
+    public QPlace(Path<? extends Place> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPlace(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPlace(PathMetadata metadata, PathInits inits) {
+        this(Place.class, metadata, inits);
+    }
+
+    public QPlace(Class<? extends Place> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.explorer.gabom.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/place/entity/QPlaceFile.java
+++ b/src/main/generated/com/explorer/gabom/domain/place/entity/QPlaceFile.java
@@ -1,0 +1,56 @@
+package com.explorer.gabom.domain.place.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPlaceFile is a Querydsl query type for PlaceFile
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPlaceFile extends EntityPathBase<PlaceFile> {
+
+    private static final long serialVersionUID = -2123652865L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPlaceFile placeFile = new QPlaceFile("placeFile");
+
+    public final com.explorer.gabom.global.file.entity.QAttachmentFile file;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> orderIdx = createNumber("orderIdx", Integer.class);
+
+    public final QPlace place;
+
+    public QPlaceFile(String variable) {
+        this(PlaceFile.class, forVariable(variable), INITS);
+    }
+
+    public QPlaceFile(Path<? extends PlaceFile> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPlaceFile(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPlaceFile(PathMetadata metadata, PathInits inits) {
+        this(PlaceFile.class, metadata, inits);
+    }
+
+    public QPlaceFile(Class<? extends PlaceFile> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.file = inits.isInitialized("file") ? new com.explorer.gabom.global.file.entity.QAttachmentFile(forProperty("file")) : null;
+        this.place = inits.isInitialized("place") ? new QPlace(forProperty("place"), inits.get("place")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/point/entity/QPointLog.java
+++ b/src/main/generated/com/explorer/gabom/domain/point/entity/QPointLog.java
@@ -1,0 +1,59 @@
+package com.explorer.gabom.domain.point.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPointLog is a Querydsl query type for PointLog
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPointLog extends EntityPathBase<PointLog> {
+
+    private static final long serialVersionUID = 303927489L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPointLog pointLog = new QPointLog("pointLog");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.LocalDateTime> loggedAt = createDateTime("loggedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> point = createNumber("point", Integer.class);
+
+    public final EnumPath<com.explorer.gabom.domain.point.type.PointType> pointType = createEnum("pointType", com.explorer.gabom.domain.point.type.PointType.class);
+
+    public final NumberPath<Long> targetId = createNumber("targetId", Long.class);
+
+    public final com.explorer.gabom.domain.user.entity.QUser user;
+
+    public QPointLog(String variable) {
+        this(PointLog.class, forVariable(variable), INITS);
+    }
+
+    public QPointLog(Path<? extends PointLog> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPointLog(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPointLog(PathMetadata metadata, PathInits inits) {
+        this(PointLog.class, metadata, inits);
+    }
+
+    public QPointLog(Class<? extends PointLog> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.explorer.gabom.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/quest/entity/QQuest.java
+++ b/src/main/generated/com/explorer/gabom/domain/quest/entity/QQuest.java
@@ -1,0 +1,74 @@
+package com.explorer.gabom.domain.quest.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QQuest is a Querydsl query type for Quest
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QQuest extends EntityPathBase<Quest> {
+
+    private static final long serialVersionUID = 1544895683L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QQuest quest = new QQuest("quest");
+
+    public final com.explorer.gabom.global.entity.QBaseTimeEntity _super = new com.explorer.gabom.global.entity.QBaseTimeEntity(this);
+
+    public final NumberPath<Integer> acquireCondition = createNumber("acquireCondition", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<com.explorer.gabom.domain.quest.type.QuestConditionType> questConditionType = createEnum("questConditionType", com.explorer.gabom.domain.quest.type.QuestConditionType.class);
+
+    public final NumberPath<Integer> rewardExp = createNumber("rewardExp", Integer.class);
+
+    public final NumberPath<Integer> rewardPoint = createNumber("rewardPoint", Integer.class);
+
+    public final com.explorer.gabom.domain.title.entity.QTitle rewardTitle;
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QQuest(String variable) {
+        this(Quest.class, forVariable(variable), INITS);
+    }
+
+    public QQuest(Path<? extends Quest> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QQuest(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QQuest(PathMetadata metadata, PathInits inits) {
+        this(Quest.class, metadata, inits);
+    }
+
+    public QQuest(Class<? extends Quest> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.rewardTitle = inits.isInitialized("rewardTitle") ? new com.explorer.gabom.domain.title.entity.QTitle(forProperty("rewardTitle")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/quest/entity/QUserQuest.java
+++ b/src/main/generated/com/explorer/gabom/domain/quest/entity/QUserQuest.java
@@ -1,0 +1,64 @@
+package com.explorer.gabom.domain.quest.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUserQuest is a Querydsl query type for UserQuest
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUserQuest extends EntityPathBase<UserQuest> {
+
+    private static final long serialVersionUID = 532098872L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUserQuest userQuest = new QUserQuest("userQuest");
+
+    public final DateTimePath<java.time.LocalDateTime> completedAt = createDateTime("completedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isRewardClaimed = createBoolean("isRewardClaimed");
+
+    public final StringPath progressData = createString("progressData");
+
+    public final EnumPath<com.explorer.gabom.domain.quest.type.ProgressStatus> progressStatus = createEnum("progressStatus", com.explorer.gabom.domain.quest.type.ProgressStatus.class);
+
+    public final QQuest quest;
+
+    public final NumberPath<Integer> rewardReceived = createNumber("rewardReceived", Integer.class);
+
+    public final com.explorer.gabom.domain.user.entity.QUser user;
+
+    public QUserQuest(String variable) {
+        this(UserQuest.class, forVariable(variable), INITS);
+    }
+
+    public QUserQuest(Path<? extends UserQuest> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUserQuest(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUserQuest(PathMetadata metadata, PathInits inits) {
+        this(UserQuest.class, metadata, inits);
+    }
+
+    public QUserQuest(Class<? extends UserQuest> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.quest = inits.isInitialized("quest") ? new QQuest(forProperty("quest"), inits.get("quest")) : null;
+        this.user = inits.isInitialized("user") ? new com.explorer.gabom.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/ranking/entity/QRanking.java
+++ b/src/main/generated/com/explorer/gabom/domain/ranking/entity/QRanking.java
@@ -1,0 +1,63 @@
+package com.explorer.gabom.domain.ranking.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRanking is a Querydsl query type for Ranking
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRanking extends EntityPathBase<Ranking> {
+
+    private static final long serialVersionUID = 568796675L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRanking ranking = new QRanking("ranking");
+
+    public final NumberPath<Integer> exp = createNumber("exp", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> level = createNumber("level", Integer.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final NumberPath<Integer> rank = createNumber("rank", Integer.class);
+
+    public final StringPath titleName = createString("titleName");
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public final com.explorer.gabom.domain.user.entity.QUser user;
+
+    public QRanking(String variable) {
+        this(Ranking.class, forVariable(variable), INITS);
+    }
+
+    public QRanking(Path<? extends Ranking> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRanking(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRanking(PathMetadata metadata, PathInits inits) {
+        this(Ranking.class, metadata, inits);
+    }
+
+    public QRanking(Class<? extends Ranking> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.explorer.gabom.domain.user.entity.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/title/entity/QTitle.java
+++ b/src/main/generated/com/explorer/gabom/domain/title/entity/QTitle.java
@@ -1,0 +1,52 @@
+package com.explorer.gabom.domain.title.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTitle is a Querydsl query type for Title
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTitle extends EntityPathBase<Title> {
+
+    private static final long serialVersionUID = 1753664643L;
+
+    public static final QTitle title = new QTitle("title");
+
+    public final com.explorer.gabom.global.entity.QBaseTimeEntity _super = new com.explorer.gabom.global.entity.QBaseTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final StringPath description = createString("description");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QTitle(String variable) {
+        super(Title.class, forVariable(variable));
+    }
+
+    public QTitle(Path<? extends Title> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTitle(PathMetadata metadata) {
+        super(Title.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/user/entity/QSocialAccount.java
+++ b/src/main/generated/com/explorer/gabom/domain/user/entity/QSocialAccount.java
@@ -1,0 +1,57 @@
+package com.explorer.gabom.domain.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSocialAccount is a Querydsl query type for SocialAccount
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSocialAccount extends EntityPathBase<SocialAccount> {
+
+    private static final long serialVersionUID = 1832118552L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSocialAccount socialAccount = new QSocialAccount("socialAccount");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final EnumPath<com.explorer.gabom.domain.user.type.SocialProvider> provider = createEnum("provider", com.explorer.gabom.domain.user.type.SocialProvider.class);
+
+    public final StringPath providerId = createString("providerId");
+
+    public final QUser user;
+
+    public QSocialAccount(String variable) {
+        this(SocialAccount.class, forVariable(variable), INITS);
+    }
+
+    public QSocialAccount(Path<? extends SocialAccount> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSocialAccount(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSocialAccount(PathMetadata metadata, PathInits inits) {
+        this(SocialAccount.class, metadata, inits);
+    }
+
+    public QSocialAccount(Class<? extends SocialAccount> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/user/entity/QUser.java
+++ b/src/main/generated/com/explorer/gabom/domain/user/entity/QUser.java
@@ -1,0 +1,87 @@
+package com.explorer.gabom.domain.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = -43061837L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUser user = new QUser("user");
+
+    public final com.explorer.gabom.global.entity.QBaseTimeEntity _super = new com.explorer.gabom.global.entity.QBaseTimeEntity(this);
+
+    public final StringPath address = createString("address");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = _super.deletedAt;
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Integer> exp = createNumber("exp", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Double> lat = createNumber("lat", Double.class);
+
+    public final NumberPath<Integer> level = createNumber("level", Integer.class);
+
+    public final NumberPath<Double> lng = createNumber("lng", Double.class);
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final NumberPath<Integer> point = createNumber("point", Integer.class);
+
+    public final com.explorer.gabom.global.file.entity.QAttachmentFile profileImg;
+
+    public final EnumPath<com.explorer.gabom.domain.user.type.UserStatus> status = createEnum("status", com.explorer.gabom.domain.user.type.UserStatus.class);
+
+    public final com.explorer.gabom.domain.title.entity.QTitle title;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public final EnumPath<com.explorer.gabom.domain.user.type.UserRole> userRole = createEnum("userRole", com.explorer.gabom.domain.user.type.UserRole.class);
+
+    public QUser(String variable) {
+        this(User.class, forVariable(variable), INITS);
+    }
+
+    public QUser(Path<? extends User> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUser(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUser(PathMetadata metadata, PathInits inits) {
+        this(User.class, metadata, inits);
+    }
+
+    public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.profileImg = inits.isInitialized("profileImg") ? new com.explorer.gabom.global.file.entity.QAttachmentFile(forProperty("profileImg")) : null;
+        this.title = inits.isInitialized("title") ? new com.explorer.gabom.domain.title.entity.QTitle(forProperty("title")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/domain/user/entity/QUserBlock.java
+++ b/src/main/generated/com/explorer/gabom/domain/user/entity/QUserBlock.java
@@ -1,0 +1,56 @@
+package com.explorer.gabom.domain.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUserBlock is a Querydsl query type for UserBlock
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUserBlock extends EntityPathBase<UserBlock> {
+
+    private static final long serialVersionUID = -651854182L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUserBlock userBlock = new QUserBlock("userBlock");
+
+    public final QUser blocked;
+
+    public final QUser blocker;
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public QUserBlock(String variable) {
+        this(UserBlock.class, forVariable(variable), INITS);
+    }
+
+    public QUserBlock(Path<? extends UserBlock> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUserBlock(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUserBlock(PathMetadata metadata, PathInits inits) {
+        this(UserBlock.class, metadata, inits);
+    }
+
+    public QUserBlock(Class<? extends UserBlock> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.blocked = inits.isInitialized("blocked") ? new QUser(forProperty("blocked"), inits.get("blocked")) : null;
+        this.blocker = inits.isInitialized("blocker") ? new QUser(forProperty("blocker"), inits.get("blocker")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/global/entity/QBaseTimeEntity.java
+++ b/src/main/generated/com/explorer/gabom/global/entity/QBaseTimeEntity.java
@@ -1,0 +1,41 @@
+package com.explorer.gabom.global.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = 31269291L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> deletedAt = createDateTime("deletedAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/explorer/gabom/global/file/entity/QAttachmentFile.java
+++ b/src/main/generated/com/explorer/gabom/global/file/entity/QAttachmentFile.java
@@ -1,0 +1,51 @@
+package com.explorer.gabom.global.file.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAttachmentFile is a Querydsl query type for AttachmentFile
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAttachmentFile extends EntityPathBase<AttachmentFile> {
+
+    private static final long serialVersionUID = -2078738983L;
+
+    public static final QAttachmentFile attachmentFile = new QAttachmentFile("attachmentFile");
+
+    public final StringPath fileId = createString("fileId");
+
+    public final StringPath fileName = createString("fileName");
+
+    public final NumberPath<Long> fileSize = createNumber("fileSize", Long.class);
+
+    public final EnumPath<com.explorer.gabom.global.file.type.FileType> fileType = createEnum("fileType", com.explorer.gabom.global.file.type.FileType.class);
+
+    public final StringPath fileUrl = createString("fileUrl");
+
+    public final StringPath mimeType = createString("mimeType");
+
+    public final NumberPath<Integer> orderIdx = createNumber("orderIdx", Integer.class);
+
+    public final NumberPath<Long> refId = createNumber("refId", Long.class);
+
+    public QAttachmentFile(String variable) {
+        super(AttachmentFile.class, forVariable(variable));
+    }
+
+    public QAttachmentFile(Path<? extends AttachmentFile> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAttachmentFile(PathMetadata metadata) {
+        super(AttachmentFile.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/explorer/gabom/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/explorer/gabom/domain/place/controller/PlaceController.java
@@ -32,8 +32,8 @@ public class PlaceController {
 		/* TODO : 인증 로직 들어오면 주석해제
 		@AuthenticationPrincipal User user */
 	) {
-		Long userId = 1L; // TODO: 인증 붙으면 교체
-		PlaceCreateResponse response = placeService.createPlace(request, userId);
+		Long userId = 1L;
+		PlaceCreateResponse response = placeService.createPlace(request, userId); // TODO: 인증 붙으면 교체
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 							 .body(ApiResponse.success("장소 등록이 완료되었습니다.", response));
@@ -51,8 +51,7 @@ public class PlaceController {
 		/* TODO : 인증 로직 들어오면 주석해제
 		@AuthenticationPrincipal User user */
 	) {
-		Long userId = 1L; // TODO: 인증 붙으면 교체
-		placeService.updatePlace(placeId, request, userId);
+		placeService.updatePlace(placeId, 1L, request); // TODO: 인증 들어오면 교체 예정
 		return ResponseEntity.ok(ApiResponse.success("장소가 수정되었습니다."));
 	}
 

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.explorer.gabom.domain.place.entity.Place;
 
-public interface PlaceRepository extends JpaRepository<Place, Long> {
+public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceRepositoryCustom {
 
 }

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryCustom.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.explorer.gabom.domain.place.repository;
+
+import com.explorer.gabom.domain.place.dto.request.PlaceUpdateRequest;
+import com.explorer.gabom.domain.place.entity.Place;
+
+public interface PlaceRepositoryCustom {
+
+	Place updatePlace(Long placeId, Long userId, PlaceUpdateRequest request);
+}

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.explorer.gabom.domain.place.repository;
+
+import com.explorer.gabom.domain.place.dto.request.PlaceUpdateRequest;
+import com.explorer.gabom.domain.place.entity.Place;
+import com.explorer.gabom.domain.place.entity.QPlace;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+	private final PlaceRepository placeRepository;
+
+	@Override
+	public Place updatePlace(Long placeId, Long userId, PlaceUpdateRequest request) {
+		QPlace place = QPlace.place;
+
+		long updated = queryFactory.update(place)
+								   .set(place.title, request.getTitle())
+								   .set(place.address, request.getAddress())
+								   .set(place.lat, request.getLat())
+								   .set(place.lng, request.getLng())
+								   .set(place.proofMethod, request.getProofMethod())
+								   .set(place.content, request.getContent())
+								   .where(place.id.eq(placeId).and(place.user.id.eq(userId)))
+								   .execute();
+
+		if (updated == 0) return null;
+
+		return placeRepository.findById(placeId)
+							  .orElseThrow(() -> new IllegalArgumentException("업데이트 후 Place 조회를 실패했습니다."));
+	}
+}

--- a/src/main/java/com/explorer/gabom/domain/place/service/PlaceService.java
+++ b/src/main/java/com/explorer/gabom/domain/place/service/PlaceService.java
@@ -39,23 +39,11 @@ public class PlaceService {
 
 	// 탐험 장소 수정
 	@Transactional
-	public void updatePlace(Long placeId, PlaceUpdateRequest request, Long userId) {
-		Place place = placeRepository.findById(placeId)
-									 .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
-
-		// 작성자 확인
-		if (!place.getUser().getId().equals(userId)) {
+	public void updatePlace(Long placeId, Long userId, PlaceUpdateRequest request) {
+		Place updatedPlace = placeRepository.updatePlace(placeId, userId, request);
+		if (updatedPlace == null) {
 			throw new CustomException(ErrorCode.PLACE_NO_PERMISSION);
 		}
-
-		place.updatePlace(
-			request.getTitle(),
-			request.getAddress(),
-			request.getLat(),
-			request.getLng(),
-			request.getContent(),
-			request.getProofMethod()
-		);
 	}
 
 	// 탐험 장소 삭제

--- a/src/main/java/com/explorer/gabom/global/config/QuerydslConfig.java
+++ b/src/main/java/com/explorer/gabom/global/config/QuerydslConfig.java
@@ -1,0 +1,23 @@
+package com.explorer.gabom.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
+++ b/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
 	TITLE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 칭호입니다."),
 
 	TITLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 칭호를 찾을 수 없습니다."),
-  
+
 	// Valid
 	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "Validation Error"),
 
@@ -32,12 +32,11 @@ public enum ErrorCode {
 
 	PLACE_NO_PERMISSION(HttpStatus.FORBIDDEN, "해당 장소에 대한 권한이 없습니다."),
 
-	// Title
-	TITLE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 칭호를 찾을 수 없습니다."),
+	NO_FIELDS_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 값이 없습니다."),
 
 	// Quest
 	QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 퀘스트를 찾을 수 없습니다.");
-  
+
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,8 +13,8 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/gabom?serverTimezone=Asia/Seoul
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
+    username: ${MYSQL_USERNAME:root}
+    password: ${MYSQL_PASSWORD:1234}
   jpa:
     hibernate:
       ddl-auto: create-drop

--- a/src/test/java/com/explorer/gabom/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/explorer/gabom/domain/user/service/UserServiceImplTest.java
@@ -20,12 +20,14 @@ import com.explorer.gabom.domain.user.type.UserRole;
 import com.explorer.gabom.domain.user.type.UserStatus;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
+import com.explorer.gabom.global.file.repository.AttachmentFileRepository;
 
 class UserServiceImplTest {
 
 	@Mock
 	private UserRepository userRepository;
-
+	@Mock
+	private AttachmentFileRepository attachmentFileRepository;
 	private UserServiceImpl userService;
 
 	private User user;
@@ -33,7 +35,7 @@ class UserServiceImplTest {
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
-		userService = new UserServiceImpl(userRepository);
+		userService = new UserServiceImpl(userRepository, attachmentFileRepository);
 
 		// 공통 User 객체 생성
 		Long userId = 1L;


### PR DESCRIPTION
## 📌 개요
> 장소 수정 시, 요청으로 전달된 필드만 선택적으로 업데이트하도록 QueryDSL 적용
## ✅ 작업 사항
- PlaceRepositoryCustom, PlaceRepositoryImpl 추가
- updatePlace(placeId, userId, request) 구현
- PlaceRepository에 Custom 인터페이스 상속
- PlaceService.updatePlace()에서 Custom 메서드 호출하도록 수정
- 수정할 값이 없을 때 NO_FIELDS_TO_UPDATE 예외 반환

## 🔍 리뷰 요청 포인트

## 💬 기타 사항
- 관련 이슈: #100 