### PR TITLE
Feat: 유저-퀘스트 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/quest/entity/UserQuest.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/entity/UserQuest.java
@@ -2,14 +2,10 @@ package com.explorer.gabom.domain.quest.entity;
 
 import java.time.LocalDateTime;
 
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import com.explorer.gabom.domain.quest.type.ProgressStatus;
 import com.explorer.gabom.domain.user.entity.User;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -19,10 +15,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Entity
 @Table(name = "user_quest")
-@EntityListeners(AuditingEntityListener.class)
+@Getter
 public class UserQuest {
 
 	@Id
@@ -38,15 +35,28 @@ public class UserQuest {
 	private Quest quest;
 
 	@Enumerated(EnumType.STRING)
-	private ProgressStatus progressStatus;
+	private ProgressStatus progressStatus = ProgressStatus.IN_PROGRESS;
+
+	private int progressCount = 0;
 
 	@Lob
 	private String progressData;
 
-	@CreatedDate
 	private LocalDateTime completedAt;
 
-	private Integer rewardReceived;
+	private boolean rewardClaimed = false;
 
-	private Boolean isRewardClaimed;
+	public void increaseProgress(int step) {
+		if (!isCompleted()) {
+			this.progressCount += step;
+			if (this.progressCount >= quest.getAcquireCondition()) {
+				this.progressStatus = ProgressStatus.COMPLETED;
+				this.completedAt = LocalDateTime.now();
+			}
+		}
+	}
+
+	public boolean isCompleted() {
+		return this.progressStatus == ProgressStatus.COMPLETED;
+	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepository.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepository.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.quest.repository;public interface UserQuestRepository {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepository.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepository.java
@@ -1,2 +1,20 @@
-package com.explorer.gabom.domain.quest.repository;public interface UserQuestRepository {
+package com.explorer.gabom.domain.quest.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.explorer.gabom.domain.quest.entity.UserQuest;
+import com.explorer.gabom.domain.quest.type.ProgressStatus;
+import com.explorer.gabom.domain.quest.type.QuestConditionType;
+import com.explorer.gabom.domain.user.entity.User;
+
+public interface UserQuestRepository extends JpaRepository<UserQuest, Long> {
+
+	List<UserQuest> findByUserAndQuest_QuestConditionTypeAndProgressStatus(
+		User user,
+		QuestConditionType questConditionType,
+		ProgressStatus progressStatus
+	);
+
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/service/AdminQuestServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/AdminQuestServiceImpl.java
@@ -12,7 +12,7 @@ import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponse;
 import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.repository.QuestRepository;
 import com.explorer.gabom.domain.title.entity.Title;
-import com.explorer.gabom.domain.title.repository.AdminTitleRepository;
+import com.explorer.gabom.domain.title.repository.TitleRepository;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
 
@@ -26,14 +26,14 @@ import lombok.extern.slf4j.Slf4j;
 public class AdminQuestServiceImpl implements AdminQuestService {
 
 	private final QuestRepository questRepository;
-	private final AdminTitleRepository adminTitleRepository;
+	private final TitleRepository titleRepository;
 
 	@Override
 	@Transactional
 	@ActivityLoggable(ActivityType.ADMIN_QUEST_CREATED)
 	public QuestCreateResponse createQuest(QuestCreateRequest dto) {
-		Title rewardTitle = adminTitleRepository.findById(dto.getRewardTitleId())
-												.orElseThrow(() -> new CustomException(ErrorCode.TITLE_NOT_FOUND));
+		Title rewardTitle = titleRepository.findById(dto.getRewardTitleId())
+										   .orElseThrow(() -> new CustomException(ErrorCode.TITLE_NOT_FOUND));
 
 		Quest quest = new Quest(
 			dto.getTitle(),
@@ -58,8 +58,8 @@ public class AdminQuestServiceImpl implements AdminQuestService {
 
 		Title rewardTitle = null;
 		if (dto.getRewardTitleId() != null) {
-			rewardTitle = adminTitleRepository.findById(dto.getRewardTitleId())
-											  .orElseThrow(() -> new CustomException(ErrorCode.TITLE_NOT_FOUND));
+			rewardTitle = titleRepository.findById(dto.getRewardTitleId())
+										 .orElseThrow(() -> new CustomException(ErrorCode.TITLE_NOT_FOUND));
 		}
 
 		quest.update(dto, rewardTitle);

--- a/src/main/java/com/explorer/gabom/domain/quest/service/QuestProgressService.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/QuestProgressService.java
@@ -1,2 +1,31 @@
-package com.explorer.gabom.domain.quest.service;public class QuestProgressService {
+package com.explorer.gabom.domain.quest.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.explorer.gabom.domain.quest.entity.UserQuest;
+import com.explorer.gabom.domain.quest.repository.UserQuestRepository;
+import com.explorer.gabom.domain.quest.type.ProgressStatus;
+import com.explorer.gabom.domain.quest.type.QuestConditionType;
+import com.explorer.gabom.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class QuestProgressService {
+
+	private final UserQuestRepository userQuestRepository;
+
+	public void updateProgress(User user, QuestConditionType type, int step) {
+		List<UserQuest> userQuests = userQuestRepository
+			.findByUserAndQuest_QuestConditionTypeAndProgressStatus(user, type, ProgressStatus.IN_PROGRESS);
+
+		for (UserQuest userQuest : userQuests) {
+			userQuest.increaseProgress(step);
+		}
+
+		userQuestRepository.saveAll(userQuests);
+	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/service/QuestProgressService.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/QuestProgressService.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.quest.service;public class QuestProgressService {
+}


### PR DESCRIPTION
## 📌 개요
유저-퀘스트 업데이트 기능 추가

## ✅ 작업 사항
- [x] 유저-퀘스트 진행 상황 업데이트 updateProgress 메서드 작성
- [x] 로그인, 인증글 작성, 지역 탐사와 같은 퀘스트가 있는 활동 시 updateProgress를 사용하여 유저-퀘스트를 업데이트 할 수 있도록 작성
- [x] 유저-퀘스트의 진행 상황이 퀘스트의 완료조건을 충족한 경우 유저-퀘스트의 진행 상태를 완료 상태로 변경 

## 🔍 리뷰 요청 포인트
- UserQuest Entity에 수정할 부분이 있는지 확인 부탁드립니다.

## 💬 기타 사항
- 관련 이슈: #72 

---
