### PR TITLE
[Fix] #130 관리자 회원가입 시 권한이 USER로 저장되는 버그 수정

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/dto/request/SignupRequest.java
@@ -1,5 +1,7 @@
 package com.explorer.gabom.domain.auth.dto.request;
 
+import com.explorer.gabom.domain.user.type.UserRole;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -22,5 +24,5 @@ public class SignupRequest {
 	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}$", message = "비밀번호는 최소 8글자 이상, 대소문자 하나 이상 포함해야합니다.")
 	private String password;
 	@NotBlank(message = "사용자, 관리자를 선택해주세요.")
-	private String role;
+	private UserRole role;
 }

--- a/src/main/java/com/explorer/gabom/domain/auth/service/AuthService.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/service/AuthService.java
@@ -9,7 +9,6 @@ import com.explorer.gabom.domain.auth.dto.response.LoginResponse;
 import com.explorer.gabom.domain.auth.dto.response.SignupResponse;
 import com.explorer.gabom.domain.user.entity.User;
 import com.explorer.gabom.domain.user.repository.UserRepository;
-import com.explorer.gabom.domain.user.type.UserRole;
 import com.explorer.gabom.domain.user.type.UserStatus;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
@@ -43,7 +42,7 @@ public class AuthService {
 						.email(request.getEmail())
 						.password(encodePassword)
 						.nickname(request.getNickname())
-						.userRole(UserRole.USER)
+						.userRole(request.getRole())
 						.build();
 
 		User savedUser = userRepository.save(user);


### PR DESCRIPTION
## 📌 개요
관리자 회원가입 시 권한이 USER로 저장되는 버그 수정

## ✅ 작업 사항
- SignupRequest에서 전달된 role 값이 무시되고 기본값(USER)으로 저장되는 문제를 해결.
- 요청으로 넘어온 문자열을 UserRole enum으로 정상 매핑하도록 처리

## 🔍 리뷰 요청 포인트
- 예: 로직 흐름 자연스러운지 확인 부탁드립니다.
- 예: 유효성 검증 누락된 부분 없는지 봐주세요.

## 💬 기타 사항
- 관련 이슈: #130 
- 참고 자료: [링크]

---
