### PR TITLE
fix: 장소 등록 시 탈퇴 유저 조회되지 않도록 수정

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/place/service/PlaceService.java
+++ b/src/main/java/com/explorer/gabom/domain/place/service/PlaceService.java
@@ -13,6 +13,7 @@ import com.explorer.gabom.domain.place.entity.PlaceStatus;
 import com.explorer.gabom.domain.place.repository.PlaceRepository;
 import com.explorer.gabom.domain.user.entity.User;
 import com.explorer.gabom.domain.user.repository.UserRepository;
+import com.explorer.gabom.domain.user.type.UserStatus;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
 
@@ -27,7 +28,8 @@ public class PlaceService {
 
 	// 탐험 장소 생성
 	public PlaceCreateResponse createPlace(PlaceCreateRequest request, Long userId) {
-		User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+		User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+								  .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		Place place = new Place(request, user);
 		Place savedPlace = placeRepository.save(place);


### PR DESCRIPTION
## 📌 개요
장소 등록 시 탈퇴 유저 조회되지 않도록 수정

## ✅ 작업 사항
- [x] findById → findByIdAndStatus 변경

## 🔍 리뷰 요청 포인트

## 💬 기타 사항
- 관련 이슈: #141
- #124  에서 세경님이 말씀하신 부분 수정입니다.