### PR TITLE
refactor: 회원가입, 테스트회원가입 분리

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/controller/AuthController.java
@@ -1,45 +1,47 @@
 package com.explorer.gabom.domain.auth.controller;
 
 import com.explorer.gabom.domain.auth.dto.request.LoginRequest;
+import com.explorer.gabom.domain.auth.dto.request.SignupRequest;
 import com.explorer.gabom.domain.auth.dto.response.CheckNicknameResponse;
 import com.explorer.gabom.domain.auth.dto.response.LoginResponse;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.explorer.gabom.domain.auth.dto.request.SignupRequest;
 import com.explorer.gabom.domain.auth.dto.response.SignupResponse;
 import com.explorer.gabom.domain.auth.service.AuthService;
 import com.explorer.gabom.global.dto.ApiResponse;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
-	private final AuthService authService;
+    private final AuthService authService;
 
-	@PostMapping("/signup")
-	public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody @Valid SignupRequest requestDto) {
-		SignupResponse response = authService.signup(requestDto);
-		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("회원가입을 성공했습니다.", response));
-	}
-	@PostMapping("/login")
-	public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
-		LoginResponse response = authService.login(request);
-		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("로그인을 성공했습니다.", response));
-	}
-	@GetMapping("/check-nickname")
-	public ResponseEntity<ApiResponse<CheckNicknameResponse>> checkNickname(@RequestParam String nickname) {
-		CheckNicknameResponse response = authService.checkNickname(nickname);
-		return ResponseEntity.ok(ApiResponse.success("닉네임 중복확인을 완료하였습니다.", response));
-	}
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody @Valid SignupRequest requestDto) {
+        SignupResponse response = authService.signup(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("회원가입을 성공했습니다.", response));
+    }
+
+    // 포스트맨 회원가입시 테스트용
+    @PostMapping("/test/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> testSignup(@RequestBody @Valid SignupRequest requestDto) {
+        SignupResponse response = authService.signup(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("회원가입을 성공했습니다.", response));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("로그인을 성공했습니다.", response));
+    }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<ApiResponse<CheckNicknameResponse>> checkNickname(@RequestParam String nickname) {
+        CheckNicknameResponse response = authService.checkNickname(nickname);
+        return ResponseEntity.ok(ApiResponse.success("닉네임 중복확인을 완료하였습니다.", response));
+    }
 
 }

--- a/src/main/java/com/explorer/gabom/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/controller/AuthController.java
@@ -28,7 +28,7 @@ public class AuthController {
     // 포스트맨 회원가입시 테스트용
     @PostMapping("/test/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> testSignup(@RequestBody @Valid SignupRequest requestDto) {
-        SignupResponse response = authService.signup(requestDto);
+        SignupResponse response = authService.testSignup(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("회원가입을 성공했습니다.", response));
     }
 

--- a/src/main/java/com/explorer/gabom/domain/auth/dto/request/EmailCodeVerifyRequest.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/dto/request/EmailCodeVerifyRequest.java
@@ -14,4 +14,8 @@ public class EmailCodeVerifyRequest {
     private final String email;
     @NotBlank(message = "인증코드 입력은 필수입니다.")
     private final String code;
+
+    public static EmailCodeVerifyRequest onlyEmail(String email) {
+        return new EmailCodeVerifyRequest(email,null);
+    }
 }

--- a/src/main/java/com/explorer/gabom/domain/auth/service/AuthService.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/service/AuthService.java
@@ -1,8 +1,6 @@
 package com.explorer.gabom.domain.auth.service;
 
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-
+import com.explorer.gabom.domain.auth.dto.request.EmailCodeVerifyRequest;
 import com.explorer.gabom.domain.auth.dto.request.LoginRequest;
 import com.explorer.gabom.domain.auth.dto.request.SignupRequest;
 import com.explorer.gabom.domain.auth.dto.response.CheckNicknameResponse;
@@ -15,62 +13,97 @@ import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
 import com.explorer.gabom.global.security.jwt.JwtProvider;
 import com.explorer.gabom.global.validator.PasswordValidator;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-	private final UserRepository userRepository;
-	private final PasswordEncoder passwordEncoder;
-	private final PasswordValidator passwordValidator;
-	private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final PasswordValidator passwordValidator;
+    private final JwtProvider jwtProvider;
+    private final EmailCodeStorageService emailCodeStorageService;
 
-	public SignupResponse signup(SignupRequest request) {
-		// 이메일 중복 체크
-		if (userRepository.existsByEmail(request.getEmail())) {
-			throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
-		}
-		// 닉네임 중복 체크
-		if (userRepository.existsByNickname(request.getNickname())) {
-			throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
-		}
-		// 비밀번호
-		String encodePassword = passwordEncoder.encode(request.getPassword());
+    public SignupResponse signup(SignupRequest request) {
+        // 이메일 중복 체크
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+        // 이메일 인증 체크
+        EmailCodeVerifyRequest verifiedRequest = new EmailCodeVerifyRequest(request.getEmail(), null);
+        if (!emailCodeStorageService.isEmailVerified(verifiedRequest)) {
+            throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+        // 닉네임 중복 체크
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+        // 비밀번호
+        String encodePassword = passwordEncoder.encode(request.getPassword());
 
-		// user
-		User user = User.builder()
-						.email(request.getEmail())
-						.password(encodePassword)
-						.nickname(request.getNickname())
-						.userRole(request.getRole())
-						.build();
+        // user
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(encodePassword)
+                .nickname(request.getNickname())
+                .userRole(request.getRole())
+                .build();
 
-		User savedUser = userRepository.save(user);
+        User savedUser = userRepository.save(user);
 
-		return SignupResponse.toDto(savedUser);
-	}
+        return SignupResponse.toDto(savedUser);
+    }
 
-	// 로그인
-	public LoginResponse login(LoginRequest request) {
-		// 이메일로 유저 가져오기
-		User user = userRepository.findByEmailAndStatus(request.getEmail(), UserStatus.ACTIVE)
-								  .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-		// 비밀번호 일치 확인
-		passwordValidator.verifyMatch(request.getPassword(), user.getPassword());
+    // 포스트맨 회원가입시 테스트용
+    public SignupResponse testSignup(SignupRequest request) {
+        // 이메일 중복 체크
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+        // 닉네임 중복 체크
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+        // 비밀번호
+        String encodePassword = passwordEncoder.encode(request.getPassword());
 
-		//토큰을 생성
-		String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
-		String refreshToken = jwtProvider.createRefreshToken(user.getId(), user.getUserRole());
+        // user
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(encodePassword)
+                .nickname(request.getNickname())
+                .userRole(request.getRole())
+                .build();
 
-		return LoginResponse.toDto(accessToken, refreshToken);
-	}
-	// 닉네임 중복 확인
-	public CheckNicknameResponse checkNickname(String nickname) {
-		boolean exists = userRepository.existsByNickname(nickname);
-		if (exists) {
-			throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
-		}
-		return new CheckNicknameResponse(true);
-	}
+        User savedUser = userRepository.save(user);
+
+        return SignupResponse.toDto(savedUser);
+    }
+
+    // 로그인
+    public LoginResponse login(LoginRequest request) {
+        // 이메일로 유저 가져오기
+        User user = userRepository.findByEmailAndStatus(request.getEmail(), UserStatus.ACTIVE)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        // 비밀번호 일치 확인
+        passwordValidator.verifyMatch(request.getPassword(), user.getPassword());
+
+        //토큰을 생성
+        String accessToken = jwtProvider.createAccessToken(user.getId(), user.getUserRole());
+        String refreshToken = jwtProvider.createRefreshToken(user.getId(), user.getUserRole());
+
+        return LoginResponse.toDto(accessToken, refreshToken);
+    }
+
+    // 닉네임 중복 확인
+    public CheckNicknameResponse checkNickname(String nickname) {
+        boolean exists = userRepository.existsByNickname(nickname);
+        if (exists) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+        return new CheckNicknameResponse(true);
+    }
+
 }

--- a/src/main/java/com/explorer/gabom/domain/auth/service/AuthService.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/service/AuthService.java
@@ -32,7 +32,7 @@ public class AuthService {
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
         // 이메일 인증 체크
-        EmailCodeVerifyRequest verifiedRequest = new EmailCodeVerifyRequest(request.getEmail(), null);
+        EmailCodeVerifyRequest verifiedRequest = EmailCodeVerifyRequest.onlyEmail(request.getEmail());
         if (!emailCodeStorageService.isEmailVerified(verifiedRequest)) {
             throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
         }

--- a/src/main/java/com/explorer/gabom/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/service/EmailAuthService.java
@@ -46,14 +46,14 @@ public class EmailAuthService {
     }
 
     // 이메일 인증코드 검증
-    public void verifyAuthCode(EmailCodeVerifyRequest request) {
-        String email = request.getEmail();
-        String code = request.getCode();
+    public void verifyAuthCode(EmailCodeVerifyRequest verifiedRequest) {
+        String email = verifiedRequest.getEmail();
+        String code = verifiedRequest.getCode();
 
         log.debug("이메일 인증 요청: email={}, code={}", email, code);
 
         //이미 인증된 이메일인지 확인
-        if (emailCodeStorageService.isEmailVerified(request)) {
+        if (emailCodeStorageService.isEmailVerified(verifiedRequest)) {
             log.warn("이미 인증된 이메일: {}", email);
             throw new CustomException(ErrorCode.EMAIL_ALREADY_VERIFIED);
         }
@@ -72,7 +72,7 @@ public class EmailAuthService {
         emailCodeStorageService.deleteEmailAuthCode(new EmailRequest(email));
 
         // 인증 상태를 유지(10분 유지)
-        emailCodeStorageService.setEmailVerified(request, 600);
+        emailCodeStorageService.setEmailVerified(verifiedRequest, 600);
         log.info("이메일 인증 성공: {}", email);
     }
 }

--- a/src/main/java/com/explorer/gabom/domain/auth/service/EmailCodeStorageService.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/service/EmailCodeStorageService.java
@@ -32,15 +32,15 @@ public class EmailCodeStorageService {
     }
 
     // 인증 완료 여부 확인
-    public boolean isEmailVerified(EmailCodeVerifyRequest request) {
-        String email = request.getEmail();
+    public boolean isEmailVerified(EmailCodeVerifyRequest verifiedRequest) {
+        String email = verifiedRequest.getEmail();
         String checkEmail = redisTemplate.opsForValue().get("EMAIL_VERIFIED:" + email);
         return "true".equals(checkEmail);
     }
 
     // 인증 완료 상태 저장
-    public void setEmailVerified(EmailCodeVerifyRequest request, long expirationSeconds) {
-        String email = request.getEmail();
+    public void setEmailVerified(EmailCodeVerifyRequest verifiedRequest, long expirationSeconds) {
+        String email = verifiedRequest.getEmail();
         redisTemplate.opsForValue().set("EMAIL_VERIFIED:" + email, "true", expirationSeconds, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
+++ b/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
@@ -40,7 +40,8 @@ public enum ErrorCode {
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
 	EXPIRED_CODE(HttpStatus.UNAUTHORIZED,"만료된 인증코드입니다."),
 	CODE_NOT_MATCH(HttpStatus.FORBIDDEN, "인증코드가 일치하지 않습니다."),
-	EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT,"이미 검증된 이메일입니다." ),
+	EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT,"이미 인증된 이메일입니다." ),
+	EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED,"인증되지 않은 이메일입니다." ),
 	// File
 	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
 	INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),


### PR DESCRIPTION
## 📌 개요
PR 내용 간단 요약

회원가입, 테스트회원가입 분리

## ✅ 작업 사항

- 포스트맨에서 테스트용 URL은 /api/auth/test/signup 으로 변경되었습니다.
- 기존에 사용하던 /api/auth/signup 은 이제 이메일인증을 필요로 합니다.

## 🔍 리뷰 요청 포인트
- 예: 로직 흐름 자연스러운지 확인 부탁드립니다.
- 예: 유효성 검증 누락된 부분 없는지 봐주세요.

## 💬 기타 사항
- 관련 이슈: #168
- 참고 자료: [링크]

---
