### PR TITLE
[Feature] #45 비밀번호 재설정 인증 코드 전송 기능 구현

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/auth/controller/EmailAuthController.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/controller/EmailAuthController.java
@@ -2,7 +2,9 @@ package com.explorer.gabom.domain.auth.controller;
 
 import com.explorer.gabom.domain.auth.dto.request.EmailCodeVerifyRequest;
 import com.explorer.gabom.domain.auth.dto.request.EmailRequest;
+import com.explorer.gabom.domain.auth.dto.request.PasswordResetRequest;
 import com.explorer.gabom.domain.auth.service.EmailAuthService;
+import com.explorer.gabom.domain.auth.service.PasswordResetService;
 import com.explorer.gabom.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,19 +17,26 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth/email")
+@RequestMapping("/api/auth")
 public class EmailAuthController {
     private final EmailAuthService emailAuthService;
+    private final PasswordResetService passwordResetService;
 
-    @PostMapping("/request")
+    @PostMapping("/email/request")
     public ResponseEntity<ApiResponse<Void>> requestEmail(@RequestBody EmailRequest request) {
         emailAuthService.sendAuthCode(request);
-        return ResponseEntity.ok(ApiResponse.success("인증 코드를 이메일로 발송했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("인증 코드를 이메일로 전송했습니다."));
     }
 
-    @PostMapping("/verify")
+    @PostMapping("/email/verify")
     public ResponseEntity<ApiResponse<Void>> verifiedEmail(@RequestBody EmailCodeVerifyRequest request) {
         emailAuthService.verifyAuthCode((request));
         return ResponseEntity.ok(ApiResponse.success("이메일 인증이 완료 되었습니다."));
+    }
+    // 비밀번호 재설정을 위한 인증코드 이메일로 전송
+    @PostMapping("password-reset/request")
+    public ResponseEntity<ApiResponse<Void>> passwordResetRequestEmail(@RequestBody PasswordResetRequest request) {
+        passwordResetService.sendResetCode(request);
+        return ResponseEntity.ok(ApiResponse.success("비밀번호 재설정 인증 코드를 이메일로 전송했습니다."));
     }
 }

--- a/src/main/java/com/explorer/gabom/domain/auth/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/dto/request/PasswordResetRequest.java
@@ -1,0 +1,14 @@
+package com.explorer.gabom.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordResetRequest {
+    @Email
+    @NotBlank(message = "이메일을 입력해 주세요.")
+    private final String email;
+}

--- a/src/main/java/com/explorer/gabom/domain/auth/service/EmailCodeStorageService.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/service/EmailCodeStorageService.java
@@ -2,6 +2,8 @@ package com.explorer.gabom.domain.auth.service;
 
 import com.explorer.gabom.domain.auth.dto.request.EmailCodeVerifyRequest;
 import com.explorer.gabom.domain.auth.dto.request.EmailRequest;
+import com.explorer.gabom.domain.auth.dto.request.PasswordResetRequest;
+import com.explorer.gabom.global.validator.PasswordValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -42,5 +44,11 @@ public class EmailCodeStorageService {
     public void setEmailVerified(EmailCodeVerifyRequest request, long expirationSeconds) {
         String email = request.getEmail();
         redisTemplate.opsForValue().set("EMAIL_VERIFIED:" + email, "true", expirationSeconds, TimeUnit.SECONDS);
+    }
+
+    // 비밀번호 재설정코드 저장
+    public void savePasswordResetCode(PasswordResetRequest request, String passWordCode,long expirationSeconds) {
+        String email = request.getEmail();
+        redisTemplate.opsForValue().set("PASSWORD_RESET_CODE:" + email, passWordCode, expirationSeconds, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/com/explorer/gabom/domain/auth/service/PasswordResetService.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/service/PasswordResetService.java
@@ -24,7 +24,7 @@ public class PasswordResetService {
     // 인증코드 전송
     public void sendResetCode(PasswordResetRequest request) {
         String email = request.getEmail();
-        if (!userRepository.existsByNickname(email)) {
+        if (!userRepository.existsByEmail(email)) {
             log.warn("가입되지 않은 이메일 요청: {}", email);
             throw new CustomException(ErrorCode.EMAIL_NOT_FOUND);
         }

--- a/src/main/java/com/explorer/gabom/domain/auth/service/PasswordResetService.java
+++ b/src/main/java/com/explorer/gabom/domain/auth/service/PasswordResetService.java
@@ -1,0 +1,46 @@
+package com.explorer.gabom.domain.auth.service;
+
+import com.explorer.gabom.domain.auth.dto.request.PasswordResetRequest;
+import com.explorer.gabom.domain.user.repository.UserRepository;
+import com.explorer.gabom.global.exception.CustomException;
+import com.explorer.gabom.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+    private final UserRepository userRepository;
+    private final JavaMailSender emailSender;
+    private final EmailCodeStorageService emailCodeStorageService;
+
+    private static final long PASSWORD_RESET_CODE_EXPIRATION_SECONDS = 300;
+
+    // 인증코드 전송
+    public void sendResetCode(PasswordResetRequest request) {
+        String email = request.getEmail();
+        if (!userRepository.existsByNickname(email)) {
+            log.warn("가입되지 않은 이메일 요청: {}", email);
+            throw new CustomException(ErrorCode.EMAIL_NOT_FOUND);
+        }
+        String authCode = generateRandomCode();
+        emailCodeStorageService.savePasswordResetCode(request, authCode, PASSWORD_RESET_CODE_EXPIRATION_SECONDS);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("비밀번호 재설정 인증코드");
+        message.setText("인증코드: " + authCode);
+
+        emailSender.send(message);
+        log.info("비밀번호 재설정 인증 코드 전송 완료: {} => {}", email, authCode);
+    }
+    // 랜덤 코드 생성
+    private String generateRandomCode() {
+        return String.format("%06d", (int) (Math.random() * 1000000));
+    }
+}

--- a/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
+++ b/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
 	EXPIRED_CODE(HttpStatus.UNAUTHORIZED,"만료된 인증코드입니다."),
 	CODE_NOT_MATCH(HttpStatus.FORBIDDEN, "인증코드가 일치하지 않습니다."),
 	EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT,"이미 검증된 이메일입니다." ),
+	EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 이메일입니다."),
 	// File
 	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
 	INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),


### PR DESCRIPTION
## 📌 개요
PR 내용 간단 요약

비밀번호 재설정 인증 코드 전송 기능 구현

## ✅ 작업 사항

테스트 순서
1. 이메일 인증코드 전송
2. 이메일 인증코드 확인 (입력한 이메일주소에서 메일함 확인)
3. 이메일 인증코드 검증 
4. 인증했던 이메일로 회원가입
5. 비밀번호 재설정 인증 코드 전송 >> (인증,회원가입)했던 동일한 이메일 입력
6. 비밀번호 재설정 인증 코드 확인(입력한 이메일주소에서 메일함 확인)
7. 
<img width="447" height="214" alt="스크린샷 2025-07-30 23 27 52" src="https://github.com/user-attachments/assets/515f0342-9859-4c60-a6a7-d37608750dcb" />



## 🔍 리뷰 요청 포인트
- 예: 로직 흐름 자연스러운지 확인 부탁드립니다.
- 예: 유효성 검증 누락된 부분 없는지 봐주세요.

## 💬 기타 사항
- 관련 이슈: #45
- 참고 자료: [링크]

---
