### PR TITLE
Refactor: 퀘스트 등록 기능 리펙토링

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/quest/dto/UserQuestDto.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/dto/UserQuestDto.java
@@ -2,6 +2,7 @@ package com.explorer.gabom.domain.quest.dto;
 
 import java.time.LocalDateTime;
 
+import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.entity.UserQuest;
 import com.explorer.gabom.domain.quest.type.ProgressStatus;
 
@@ -30,4 +31,17 @@ public class UserQuestDto {
 						   .completedAt(userQuest.getCompletedAt())
 						   .build();
 	}
+
+	public static UserQuestDto toDto(Quest quest) {
+		return UserQuestDto.builder()
+						   .userQuestId(null)
+						   .questTitle(quest.getTitle())
+						   .progressStatus(ProgressStatus.NOT_STARTED)
+						   .progressCount(0)
+						   .acquireCondition(quest.getAcquireCondition())
+						   .rewardClaimed(false)
+						   .completedAt(null)
+						   .build();
+	}
+
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/entity/UserQuest.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/entity/UserQuest.java
@@ -41,7 +41,7 @@ public class UserQuest {
 	private Quest quest;
 
 	@Enumerated(EnumType.STRING)
-	private ProgressStatus progressStatus = ProgressStatus.IN_PROGRESS;
+	private ProgressStatus progressStatus = ProgressStatus.NOT_STARTED;
 
 	private int progressCount = 0;
 
@@ -61,18 +61,17 @@ public class UserQuest {
 	public UserQuest(User user, Quest quest) {
 		this.user = user;
 		this.quest = quest;
-		this.progressCount = 0;
-		this.rewardClaimed = false;
 	}
 
 	public void increaseProgress(int step) {
-		if (!isCompleted()) {
-			this.progressCount += step;
-			if (this.progressCount >= quest.getAcquireCondition()) {
-				this.progressStatus = ProgressStatus.COMPLETED;
-				this.completedAt = LocalDateTime.now();
-			}
+		if (isCompleted())
+			return;
+
+		this.progressCount += step;
+		if (this.progressCount >= quest.getAcquireCondition()) {
+			markCompleted();
 		}
+
 	}
 
 	public boolean isCompleted() {
@@ -84,6 +83,9 @@ public class UserQuest {
 	}
 
 	public void markCompleted() {
+		if (isCompleted())
+			return;
+
 		this.progressStatus = ProgressStatus.COMPLETED;
 		this.completedAt = LocalDateTime.now();
 	}

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepository.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.explorer.gabom.domain.quest.entity.Quest;
 
-public interface QuestRepository extends JpaRepository<Quest, Long> {
+public interface QuestRepository extends JpaRepository<Quest, Long>, QuestRepositoryCustom {
 
 	Optional<Quest> findByIdAndDeletedFalse(Long id);
 

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepositoryCustom.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepositoryCustom.java
@@ -1,2 +1,15 @@
-package com.explorer.gabom.domain.quest.repository;public interface QuestRepositoryCustom {
+package com.explorer.gabom.domain.quest.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.explorer.gabom.domain.quest.entity.Quest;
+import com.explorer.gabom.domain.quest.type.QuestConditionType;
+
+public interface QuestRepositoryCustom {
+	Page<Quest> findQuestsNotJoinedByUser(Long userId, Pageable pageable);
+
+	List<Quest> findByQuestConditionTypeAndDeletedFalse(QuestConditionType questConditionType);
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepositoryCustom.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepositoryCustom.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.quest.repository;public interface QuestRepositoryCustom {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepositoryImpl.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.quest.repository;public class QuestRepositoryImpl {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/QuestRepositoryImpl.java
@@ -1,2 +1,80 @@
-package com.explorer.gabom.domain.quest.repository;public class QuestRepositoryImpl {
+package com.explorer.gabom.domain.quest.repository;
+
+import static com.explorer.gabom.domain.quest.util.QuestOrderSpecifierUtil.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.explorer.gabom.domain.quest.entity.QQuest;
+import com.explorer.gabom.domain.quest.entity.QUserQuest;
+import com.explorer.gabom.domain.quest.entity.Quest;
+import com.explorer.gabom.domain.quest.type.QuestConditionType;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestRepositoryImpl implements QuestRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	QQuest quest = QQuest.quest;
+	QUserQuest userQuest = QUserQuest.userQuest;
+
+	@Override
+	public Page<Quest> findQuestsNotJoinedByUser(Long userId, Pageable pageable) {
+		List<OrderSpecifier<?>> orders = getOrderSpecifiers(pageable);
+
+		List<Quest> contents = queryFactory
+			.selectFrom(quest)
+			.where(
+				quest.deleted.isFalse(),
+				notExistsUserQuest(userId)
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(orders.toArray(new OrderSpecifier[0]))
+			.fetch();
+
+		return PageableExecutionUtils.getPage(contents, pageable,
+											  () -> queryFactory
+												  .selectFrom(quest)
+												  .where(
+													  quest.deleted.isFalse(),
+													  notExistsUserQuest(userId)
+												  )
+												  .fetch()
+												  .size()
+		);
+	}
+
+	private BooleanExpression notExistsUserQuest(Long userId) {
+		return queryFactory
+			.selectOne()
+			.from(userQuest)
+			.where(
+				userQuest.user.id.eq(userId),
+				userQuest.quest.id.eq(quest.id),
+				userQuest.deleted.isFalse()
+			)
+			.notExists();
+	}
+
+	@Override
+	public List<Quest> findByQuestConditionTypeAndDeletedFalse(QuestConditionType questConditionType) {
+		return queryFactory
+			.selectFrom(quest)
+			.where(
+				quest.questConditionType.eq(questConditionType),
+				quest.deleted.isFalse()
+			)
+			.fetch();
+	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepository.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepository.java
@@ -3,36 +3,20 @@ package com.explorer.gabom.domain.quest.repository;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.entity.UserQuest;
-import com.explorer.gabom.domain.quest.type.ProgressStatus;
-import com.explorer.gabom.domain.quest.type.QuestConditionType;
 import com.explorer.gabom.domain.user.entity.User;
 
-public interface UserQuestRepository extends JpaRepository<UserQuest, Long> {
+public interface UserQuestRepository extends JpaRepository<UserQuest, Long>, UserQuestRepositoryCustom {
 
-	List<UserQuest> findByUserAndQuest_QuestConditionTypeAndProgressStatusAndQuest_DeletedFalse(
-		User user,
-		QuestConditionType questConditionType,
-		ProgressStatus progressStatus
-	);
+	Optional<UserQuest> findByUserAndQuest(User user, Quest quest);
 
 	List<UserQuest> findAllByQuestAndQuest_DeletedFalse(Quest quest);
 
 	List<UserQuest> findAllByQuest(Quest quest);
 
 	Optional<UserQuest> findByUser_IdAndIdAndQuest_DeletedFalse(Long userId, Long id);
-
-	Page<UserQuest> findByUser_IdAndQuest_DeletedFalse(Long userId, Pageable pageable);
-
-	Page<UserQuest> findByUser_IdAndProgressStatusAndQuest_DeletedFalse(
-		Long userId,
-		ProgressStatus progressStatus,
-		Pageable pageable
-	);
 
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryCustom.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryCustom.java
@@ -1,2 +1,16 @@
-package com.explorer.gabom.domain.quest.repository;public interface UserQuestRepositoryCustom {
+package com.explorer.gabom.domain.quest.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.explorer.gabom.domain.quest.entity.UserQuest;
+import com.explorer.gabom.domain.quest.type.ProgressStatus;
+import com.explorer.gabom.domain.quest.type.QuestConditionType;
+
+public interface UserQuestRepositoryCustom {
+	Optional<Integer> findMaxProgressByUserAndQuestType(Long userId, QuestConditionType type);
+
+	Page<UserQuest> findUserQuests(Long userId, ProgressStatus status, Pageable pageable);
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryCustom.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryCustom.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.quest.repository;public interface UserQuestRepositoryCustom {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryImpl.java
@@ -1,4 +1,75 @@
 package com.explorer.gabom.domain.quest.repository;
 
-public class UserQuestRepositoryImpl {
+import static com.explorer.gabom.domain.quest.util.QuestOrderSpecifierUtil.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.explorer.gabom.domain.quest.entity.QUserQuest;
+import com.explorer.gabom.domain.quest.entity.UserQuest;
+import com.explorer.gabom.domain.quest.type.ProgressStatus;
+import com.explorer.gabom.domain.quest.type.QuestConditionType;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQuestRepositoryImpl implements UserQuestRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	QUserQuest uq = QUserQuest.userQuest;
+
+	@Override
+	public Optional<Integer> findMaxProgressByUserAndQuestType(Long userId, QuestConditionType type) {
+		Integer result = queryFactory
+			.select(uq.progressCount.max())
+			.from(uq)
+			.where(
+				uq.user.id.eq(userId),
+				uq.quest.questConditionType.eq(type),
+				uq.deleted.isFalse()
+			)
+			.fetchOne();
+		return Optional.ofNullable(result);
+	}
+
+	@Override
+	public Page<UserQuest> findUserQuests(Long userId, ProgressStatus status, Pageable pageable) {
+		List<UserQuest> contents = queryFactory
+			.selectFrom(uq)
+			.where(
+				uq.user.id.eq(userId),
+				uq.quest.deleted.isFalse(),
+				statusEq(status)
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(getOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new))
+			.fetch();
+
+		return PageableExecutionUtils.getPage(contents, pageable,
+											  () -> queryFactory
+												  .selectFrom(uq)
+												  .where(
+													  uq.user.id.eq(userId),
+													  uq.quest.deleted.isFalse(),
+													  statusEq(status)
+												  )
+												  .fetch()
+												  .size()
+		);
+	}
+
+	private BooleanExpression statusEq(ProgressStatus status) {
+		return status != null ? uq.progressStatus.eq(status) : null;
+	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.explorer.gabom.domain.quest.repository;
+
+public class UserQuestRepositoryImpl {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/service/AdminQuestServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/AdminQuestServiceImpl.java
@@ -17,8 +17,6 @@ import com.explorer.gabom.domain.quest.repository.QuestRepository;
 import com.explorer.gabom.domain.quest.repository.UserQuestRepository;
 import com.explorer.gabom.domain.title.entity.Title;
 import com.explorer.gabom.domain.title.repository.TitleRepository;
-import com.explorer.gabom.domain.user.entity.User;
-import com.explorer.gabom.domain.user.repository.UserRepository;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
 
@@ -33,7 +31,6 @@ public class AdminQuestServiceImpl implements AdminQuestService {
 
 	private final QuestRepository questRepository;
 	private final TitleRepository titleRepository;
-	private final UserRepository userRepository;
 	private final UserQuestRepository userQuestRepository;
 
 	@Override
@@ -53,11 +50,6 @@ public class AdminQuestServiceImpl implements AdminQuestService {
 			rewardTitle
 		);
 		Quest saved = questRepository.save(quest);
-		List<User> users = userRepository.findAll();
-		List<UserQuest> userQuests = users.stream()
-										  .map(user -> new UserQuest(user, saved))
-										  .toList();
-		userQuestRepository.saveAll(userQuests);
 
 		return QuestCreateResponse.toDto(saved);
 	}

--- a/src/main/java/com/explorer/gabom/domain/quest/service/UserQuestServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/UserQuestServiceImpl.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Service;
 
 import com.explorer.gabom.domain.quest.dto.UserQuestDto;
 import com.explorer.gabom.domain.quest.dto.response.QuestRewardResponse;
+import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.entity.UserQuest;
+import com.explorer.gabom.domain.quest.repository.QuestRepository;
 import com.explorer.gabom.domain.quest.repository.UserQuestRepository;
 import com.explorer.gabom.domain.quest.type.ProgressStatus;
 import com.explorer.gabom.domain.quest.type.QuestConditionType;
@@ -27,19 +29,37 @@ public class UserQuestServiceImpl implements UserQuestService {
 
 	private final UserQuestRepository userQuestRepository;
 	private final UserRepository userRepository;
+	private final QuestRepository questRepository;
 
 	@Override
 	@Transactional
 	public void updateProgress(User user, QuestConditionType type, int step) {
-		List<UserQuest> userQuests = userQuestRepository
-			.findByUserAndQuest_QuestConditionTypeAndProgressStatusAndQuest_DeletedFalse(user, type,
-																						 ProgressStatus.IN_PROGRESS);
+		List<Quest> quests = questRepository.findByQuestConditionTypeAndDeletedFalse(type);
 
-		for (UserQuest userQuest : userQuests) {
+		for (Quest quest : quests) {
+			UserQuest userQuest = userQuestRepository.findByUserAndQuest(user, quest)
+													 .orElseGet(() -> {
+														 return createUserQuest(user, type, quest);
+													 });
+
+			if (userQuest.isCompleted())
+				continue;
+
+			if (userQuest.getProgressStatus() == ProgressStatus.NOT_STARTED) {
+				userQuest.markInProgress();
+			}
+
 			userQuest.increaseProgress(step);
 		}
+	}
 
-		userQuestRepository.saveAll(userQuests);
+	private UserQuest createUserQuest(User user, QuestConditionType type, Quest quest) {
+		int baseProgress = userQuestRepository.findMaxProgressByUserAndQuestType(
+												  user.getId(), type)
+											  .orElse(0);
+		UserQuest newUserQuest = new UserQuest(user, quest);
+		newUserQuest.increaseProgress(baseProgress);
+		return userQuestRepository.save(newUserQuest);
 	}
 
 	@Override
@@ -69,16 +89,16 @@ public class UserQuestServiceImpl implements UserQuestService {
 
 	@Override
 	public PageResponse<UserQuestDto> getProgress(Long userId, ProgressStatus progressStatus, Pageable pageable) {
-		Page<UserQuest> userQuestPage;
+		Page<UserQuestDto> userQuestDtoPage;
 
-		if (progressStatus != null) {
-			userQuestPage = userQuestRepository.findByUser_IdAndProgressStatusAndQuest_DeletedFalse(
-				userId, progressStatus, pageable);
+		if (progressStatus == ProgressStatus.NOT_STARTED) {
+			Page<Quest> notStartedQuests = questRepository.findQuestsNotJoinedByUser(userId, pageable);
+			userQuestDtoPage = notStartedQuests.map(UserQuestDto::toDto);
 		} else {
-			userQuestPage = userQuestRepository.findByUser_IdAndQuest_DeletedFalse(userId, pageable);
+			Page<UserQuest> userQuests = userQuestRepository.findUserQuests(userId, progressStatus, pageable);
+			userQuestDtoPage = userQuests.map(UserQuestDto::toDto);
 		}
 
-		Page<UserQuestDto> userQuestDtoPage = userQuestPage.map(UserQuestDto::toDto);
 		return PageResponse.toDto(userQuestDtoPage);
 	}
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/type/ProgressStatus.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/type/ProgressStatus.java
@@ -1,5 +1,7 @@
 package com.explorer.gabom.domain.quest.type;
 
 public enum ProgressStatus {
-	IN_PROGRESS, COMPLETED
+	NOT_STARTED,
+	IN_PROGRESS,
+	COMPLETED
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/util/QuestOrderSpecifierUtil.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/util/QuestOrderSpecifierUtil.java
@@ -1,0 +1,2 @@
+package com.explorer.gabom.domain.quest.util;public class QuestOrderSpecifierUtil {
+}

--- a/src/main/java/com/explorer/gabom/domain/quest/util/QuestOrderSpecifierUtil.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/util/QuestOrderSpecifierUtil.java
@@ -1,2 +1,45 @@
-package com.explorer.gabom.domain.quest.util;public class QuestOrderSpecifierUtil {
+package com.explorer.gabom.domain.quest.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.explorer.gabom.domain.quest.entity.QQuest;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+
+public class QuestOrderSpecifierUtil {
+
+	private static final QQuest quest = QQuest.quest;
+
+	public static List<OrderSpecifier<?>> getOrderSpecifiers(Pageable pageable) {
+		List<OrderSpecifier<?>> orders = new ArrayList<>();
+		for (Sort.Order order : pageable.getSort()) {
+			Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+			String property = order.getProperty();
+
+			switch (property) {
+				case "id":
+					orders.add(new OrderSpecifier<>(direction, quest.id));
+					break;
+				case "title":
+					orders.add(new OrderSpecifier<>(direction, quest.title));
+					break;
+				case "rewardPoint":
+					orders.add(new OrderSpecifier<>(direction, quest.rewardPoint));
+					break;
+				case "acquireCondition":
+					orders.add(new OrderSpecifier<>(direction, quest.acquireCondition));
+					break;
+				default:
+					break;
+			}
+		}
+		if (orders.isEmpty()) {
+			orders.add(new OrderSpecifier<>(Order.ASC, quest.id));
+		}
+		return orders;
+	}
 }


### PR DESCRIPTION
## 📌 개요
퀘스트 등록 기능 리펙토링

## ✅ 작업 사항
- [x] 관리자가 퀘스트 등록 시에 유저-퀘스트 전체 등록 -> 유저가 퀘스트 관련 활동 시에 유저-퀘스트에 해당 퀘스트가 없으면 등록하도록 변경
- [x] 서브쿼리가 필요한 Query의 경우, QueryDsl 사용

## 🔍 리뷰 요청 포인트
- QueryDsl메서드에 문제가 있는지 확인 부탁드립니다.

## 💬 기타 사항
- 관련 이슈: #51 

---
