### PR TITLE
Feat: 리소스 작성자 검증 기능 추가

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/exploration/service/ExplorationService.java
+++ b/src/main/java/com/explorer/gabom/domain/exploration/service/ExplorationService.java
@@ -19,6 +19,7 @@ import com.explorer.gabom.domain.user.repository.UserRepository;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
 import com.explorer.gabom.global.util.DistanceCalculator;
+import com.explorer.gabom.global.validator.AuthorValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +30,7 @@ public class ExplorationService {
 	private final UserRepository userRepository;
 	private final PlaceRepository placeRepository;
 	private final ExplorationRepository explorationRepository;
+	private final AuthorValidator authorValidator;
 
 	// 탐험 시작
 	@Transactional
@@ -82,9 +84,11 @@ public class ExplorationService {
 														   () -> new CustomException(ErrorCode.EXPLORATION_NOT_FOUND));
 
 		// 탐험 권한이 없는 경우
-		if (!exploration.getUser().getId().equals(userId)) {
-			throw new CustomException(ErrorCode.EXPLORATION_NO_PERMISSION);
-		}
+		authorValidator.validateOwner(
+			exploration.getUser().getId(),
+			userId
+		);
+
 		// 이미 종료된 탐험인 경우
 		if (exploration.getEndAt().isBefore(LocalDateTime.now())) {
 			throw new CustomException(ErrorCode.EXPLORATION_ALREADY_ENDED);

--- a/src/main/java/com/explorer/gabom/domain/missionproof/service/MissionProofServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/missionproof/service/MissionProofServiceImpl.java
@@ -29,6 +29,7 @@ import com.explorer.gabom.domain.user.dto.UserSummaryDto;
 import com.explorer.gabom.domain.user.entity.User;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
+import com.explorer.gabom.global.validator.AuthorValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,6 +41,7 @@ public class MissionProofServiceImpl implements MissionProofService{
 	private final MissionProofRepository missionProofRepository;
 	private final PlaceRepository placeRepository;
 	private final AttachmentFileRepository attachmentFileRepository;
+	private final AuthorValidator authorValidator;
 
 
 	// 생성
@@ -88,9 +90,10 @@ public class MissionProofServiceImpl implements MissionProofService{
 													  .orElseThrow(() -> new CustomException(NOT_FOUND_MISSION_PROOF));
 
 		// 2. 작성자 검증
-		if (!existing.getUser().getId().equals(userId)) {
-			throw new CustomException(FORBIDDEN_UPDATE_MISSION_PROOF);
-		}
+		authorValidator.validateOwner(
+			existing.getUser().getId(),
+			userId
+		);
 
 		// 3. 이미지 파일 연관 조회
 		List<AttachmentFile> imageFiles = attachmentFileRepository
@@ -135,9 +138,10 @@ public class MissionProofServiceImpl implements MissionProofService{
 	public void deleteMissionProof(Long id, Long userId) {
 		MissionProof missionProof = missionProofRepository.findByIdAndDeletedAtIsNull(id)
 														  .orElseThrow(() -> new CustomException(NOT_FOUND_MISSION_PROOF));
-		if (!missionProof.getUser().getId().equals(userId)) {
-			throw new CustomException(FORBIDDEN_DELETE_MISSION_PROOF);
-		}
+		authorValidator.validateOwner(
+			missionProof.getUser().getId(),
+			userId
+		);
 
 		missionProof.delete();
 	}

--- a/src/main/java/com/explorer/gabom/domain/place/entity/Place.java
+++ b/src/main/java/com/explorer/gabom/domain/place/entity/Place.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.SQLDelete;
 import com.explorer.gabom.domain.file.entity.AttachmentFile;
 import com.explorer.gabom.domain.missionproof.entity.MissionProof;
 import com.explorer.gabom.domain.place.dto.request.PlaceCreateRequest;
+import com.explorer.gabom.domain.place.dto.request.PlaceUpdateRequest;
 import com.explorer.gabom.domain.user.entity.User;
 import com.explorer.gabom.global.entity.BaseTimeEntity;
 
@@ -111,5 +112,14 @@ public class Place extends BaseTimeEntity {
 					.findFirst()
 					.map(PlaceFile::getFile)
 					.orElse(null);
+	}
+
+	public void update(PlaceUpdateRequest request) {
+		this.title = request.getTitle();
+		this.address = request.getAddress();
+		this.lat = request.getLat();
+		this.lng = request.getLng();
+		this.proofMethod = request.getProofMethod();
+		this.content = request.getContent();
 	}
 }

--- a/src/main/java/com/explorer/gabom/domain/place/service/PlaceServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/place/service/PlaceServiceImpl.java
@@ -26,6 +26,7 @@ import com.explorer.gabom.domain.user.type.UserStatus;
 import com.explorer.gabom.global.dto.PageResponse;
 import com.explorer.gabom.global.exception.CustomException;
 import com.explorer.gabom.global.exception.ErrorCode;
+import com.explorer.gabom.global.validator.AuthorValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,6 +37,7 @@ public class PlaceServiceImpl implements PlaceService {
 	private final PlaceRepository placeRepository;
 	private final UserRepository userRepository;
 	private final AttachmentFileRepository attachmentFileRepository;
+	private final AuthorValidator authorValidator;
 
 	@Override
 	@Transactional
@@ -103,10 +105,15 @@ public class PlaceServiceImpl implements PlaceService {
 	@Transactional
 	@Override
 	public void updatePlace(Long placeId, Long userId, PlaceUpdateRequest request) {
-		Place updatedPlace = placeRepository.updatePlace(placeId, userId, request);
-		if (updatedPlace == null) {
-			throw new CustomException(ErrorCode.PLACE_NO_PERMISSION);
-		}
+		Place place = placeRepository.findById(placeId)
+									 .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
+
+		authorValidator.validateOwner(
+			place.getUser().getId(),
+			userId
+		);
+
+		place.update(request);
 	}
 
 	@Transactional
@@ -116,9 +123,10 @@ public class PlaceServiceImpl implements PlaceService {
 										 placeId, List.of(PlaceStatus.PENDING, PlaceStatus.APPROVED))
 									 .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
 
-		if (!place.getUser().getId().equals(userId)) {
-			throw new CustomException(ErrorCode.PLACE_NO_PERMISSION);
-		}
+		authorValidator.validateOwner(
+			place.getUser().getId(),
+			userId
+		);
 
 		place.markAsDeleted(); // Soft Delete 처리
 

--- a/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
+++ b/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
@@ -51,7 +51,6 @@ public enum ErrorCode {
 
 	// Place
 	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 장소를 찾을 수 없습니다."),
-	PLACE_NO_PERMISSION(HttpStatus.FORBIDDEN, "해당 장소에 대한 권한이 없습니다."),
 	NO_FIELDS_TO_UPDATE(HttpStatus.BAD_REQUEST, "수정할 값이 없습니다."),
 
 	// Exploration

--- a/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
+++ b/src/main/java/com/explorer/gabom/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다."),
 	NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 경로를 찾을 수 없습니다."),
+	NOT_RESOURCE_OWNER(HttpStatus.FORBIDDEN, "해당 리소스 소유자가 아닙니다."),
 
 	//Title
 	TITLE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 칭호입니다."),

--- a/src/main/java/com/explorer/gabom/global/validator/AuthorValidator.java
+++ b/src/main/java/com/explorer/gabom/global/validator/AuthorValidator.java
@@ -1,0 +1,22 @@
+package com.explorer.gabom.global.validator;
+
+import org.springframework.stereotype.Component;
+
+import com.explorer.gabom.global.exception.CustomException;
+import com.explorer.gabom.global.exception.ErrorCode;
+
+@Component
+public class AuthorValidator {
+	/**
+	 * 현재 사용자가 리소스 작성자인지 검증
+	 *
+	 * @param resourceOwnerId 리소스를 작성한 사용자 ID
+	 * @param currentUserId 현재 로그인한 사용자 ID
+	 * @throws CustomException 작성자가 아닌 경우 NOT_RESOURCE_OWNER 코드가 담김 에러 리턴
+	 */
+	public void validateOwner(Long resourceOwnerId, Long currentUserId) {
+		if (!resourceOwnerId.equals(currentUserId)) {
+			throw new CustomException(ErrorCode.NOT_RESOURCE_OWNER);
+		}
+	}
+}


### PR DESCRIPTION
## 📌 개요
> 작성자 검증 (AuthorValidator)을 각 서비스 도메인에 적용하여 보안 및 무결성 강화

## ✅ 작업 사항
- [x]  ExplorationServiceImpl에 작성자 검증 추가 (exploration.getUser().getId() 기준)
- [x] MissionProofServiceImpl 수정/삭제 로직에 작성자 검증 추가
- [x] PlaceServiceImpl 수정/삭제 시 작성자 검증 로직 적용
- [x] AuthorValidator 미사용 도메인 전수 확인 및 불필요 확인 (File, User, Quest 등)

## 🔍 리뷰 요청 포인트
- AuthorValidator 로직이 적절한 위치에 삽입되었는지
- 기존 로직과 충돌 없이 자연스럽게 동작하는지
- 실수로 빠진 도메인 없는지 확인 부탁드립니다

## 💬 기타 사항
- 관련 이슈: #242 

---
