### PR TITLE
Refactor: 퀘스트 업데이트, 소프트 딜리트 시 유저-퀘스트 상태 변경 bulk update 적용

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/quest/entity/UserQuest.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/entity/UserQuest.java
@@ -96,6 +96,8 @@ public class UserQuest {
 	}
 
 	public void markAsDeleted() {
+		if (this.deleted)
+			return;
 		this.deleted = true;
 		this.deletedAt = LocalDateTime.now();
 	}

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryCustom.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryCustom.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.entity.UserQuest;
 import com.explorer.gabom.domain.quest.type.ProgressStatus;
 import com.explorer.gabom.domain.quest.type.QuestConditionType;
@@ -13,4 +14,8 @@ public interface UserQuestRepositoryCustom {
 	Optional<Integer> findMaxProgressByUserAndQuestType(Long userId, QuestConditionType type);
 
 	Page<UserQuest> findUserQuests(Long userId, ProgressStatus status, Pageable pageable);
+
+	void bulkUpdateUserQuestStatusByQuest(Quest quest);
+
+	void bulkDeleteByQuest(Quest quest);
 }

--- a/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/repository/UserQuestRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.explorer.gabom.domain.quest.repository;
 
 import static com.explorer.gabom.domain.quest.util.QuestOrderSpecifierUtil.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,6 +12,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import com.explorer.gabom.domain.quest.entity.QUserQuest;
+import com.explorer.gabom.domain.quest.entity.Quest;
 import com.explorer.gabom.domain.quest.entity.UserQuest;
 import com.explorer.gabom.domain.quest.type.ProgressStatus;
 import com.explorer.gabom.domain.quest.type.QuestConditionType;
@@ -18,6 +20,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -25,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class UserQuestRepositoryImpl implements UserQuestRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
+	private final EntityManager em;
 
 	QUserQuest uq = QUserQuest.userQuest;
 
@@ -67,6 +71,46 @@ public class UserQuestRepositoryImpl implements UserQuestRepositoryCustom {
 												  .fetch()
 												  .size()
 		);
+	}
+
+	@Override
+	public void bulkUpdateUserQuestStatusByQuest(Quest quest) {
+		LocalDateTime now = LocalDateTime.now();
+
+		queryFactory.update(uq)
+					.set(uq.progressStatus, ProgressStatus.COMPLETED)
+					.set(uq.completedAt, now)
+					.where(
+						uq.quest.eq(quest),
+						uq.deleted.isFalse(),
+						uq.progressCount.goe(quest.getAcquireCondition())
+					)
+					.execute();
+
+		queryFactory.update(uq)
+					.set(uq.progressStatus, ProgressStatus.IN_PROGRESS)
+					.set(uq.completedAt, (LocalDateTime)null)
+					.where(
+						uq.quest.eq(quest),
+						uq.deleted.isFalse(),
+						uq.progressCount.lt(quest.getAcquireCondition())
+					)
+					.execute();
+
+		em.clear();
+	}
+
+	@Override
+	public void bulkDeleteByQuest(Quest quest) {
+		LocalDateTime now = LocalDateTime.now();
+
+		queryFactory.update(uq)
+					.set(uq.deleted, true)
+					.set(uq.deletedAt, now)
+					.where(uq.quest.eq(quest))
+					.execute();
+
+		em.clear();
 	}
 
 	private BooleanExpression statusEq(ProgressStatus status) {

--- a/src/main/java/com/explorer/gabom/domain/quest/service/AdminQuestServiceImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/quest/service/AdminQuestServiceImpl.java
@@ -1,7 +1,5 @@
 package com.explorer.gabom.domain.quest.service;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 
 import com.explorer.gabom.domain.activity.aop.ActivityLoggable;
@@ -12,7 +10,6 @@ import com.explorer.gabom.domain.quest.dto.response.QuestCreateResponse;
 import com.explorer.gabom.domain.quest.dto.response.QuestDeleteResponse;
 import com.explorer.gabom.domain.quest.dto.response.QuestUpdateResponse;
 import com.explorer.gabom.domain.quest.entity.Quest;
-import com.explorer.gabom.domain.quest.entity.UserQuest;
 import com.explorer.gabom.domain.quest.repository.QuestRepository;
 import com.explorer.gabom.domain.quest.repository.UserQuestRepository;
 import com.explorer.gabom.domain.title.entity.Title;
@@ -71,20 +68,14 @@ public class AdminQuestServiceImpl implements AdminQuestService {
 			dto.getAcquireCondition() != quest.getAcquireCondition();
 
 		quest.update(dto, rewardTitle);
+		questRepository.save(quest);
+		QuestUpdateResponse response = QuestUpdateResponse.toDto(quest);
 
 		if (acquireConditionChanged) {
-			List<UserQuest> userQuests = userQuestRepository.findAllByQuestAndQuest_DeletedFalse(quest);
-			for (UserQuest userQuest : userQuests) {
-				if (userQuest.getProgressCount() >= quest.getAcquireCondition()) {
-					userQuest.markCompleted();
-				} else {
-					userQuest.markInProgress();
-				}
-			}
-			userQuestRepository.saveAll(userQuests);
+			userQuestRepository.bulkUpdateUserQuestStatusByQuest(quest);
 		}
 
-		return QuestUpdateResponse.toDto(quest);
+		return response;
 	}
 
 	@Override
@@ -96,14 +87,11 @@ public class AdminQuestServiceImpl implements AdminQuestService {
 
 		quest.markAsDeleted();
 		questRepository.save(quest);
+		QuestDeleteResponse response = QuestDeleteResponse.toDto(quest);
 
-		List<UserQuest> userQuests = userQuestRepository.findAllByQuest(quest);
-		for (UserQuest userQuest : userQuests) {
-			userQuest.markAsDeleted();
-		}
-		userQuestRepository.saveAll(userQuests);
+		userQuestRepository.bulkDeleteByQuest(quest);
 
-		return QuestDeleteResponse.toDto(quest);
+		return response;
 	}
 
 }

--- a/src/test/java/com/explorer/gabom/domain/quest/service/AdminQuestServiceTest.java
+++ b/src/test/java/com/explorer/gabom/domain/quest/service/AdminQuestServiceTest.java
@@ -3,7 +3,6 @@ package com.explorer.gabom.domain.quest.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -125,7 +124,6 @@ class AdminQuestServiceTest {
 
 		given(questRepository.findByIdAndDeletedFalse(QUEST_ID)).willReturn(Optional.of(existingQuest));
 		given(titleRepository.findById(NEW_TITLE_ID)).willReturn(Optional.of(newTitle));
-		given(userQuestRepository.findAllByQuestAndQuest_DeletedFalse(any())).willReturn(List.of());
 
 		QuestUpdateResponse response = adminQuestService.updateQuest(QUEST_ID, request);
 
@@ -158,12 +156,12 @@ class AdminQuestServiceTest {
 		UserQuest userQuest = mock(UserQuest.class);
 
 		given(questRepository.findByIdAndDeletedFalse(QUEST_ID)).willReturn(Optional.of(quest));
-		given(userQuestRepository.findAllByQuest(quest)).willReturn(List.of(userQuest));
 
 		QuestDeleteResponse response = adminQuestService.deleteQuest(QUEST_ID);
 
 		assertThat(response.getQuestId()).isEqualTo(QUEST_ID);
-		verify(userQuest).markAsDeleted();
+		verify(questRepository).findByIdAndDeletedFalse(QUEST_ID);
+		verify(userQuestRepository).bulkDeleteByQuest(any(Quest.class));
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 개요
퀘스트 업데이트, 소프트 딜리트 시 유저-퀘스트 상태 변경 bulk update 적용

## ✅ 작업 사항
- [ ] 유저-퀘스트 상태 변경 bulk update 적용
- [ ] querydsl 메서드로 작성
- [ ] 퀘스트 수정, 삭제 테스트 코드 수정

## 🔍 리뷰 요청 포인트
- 퀘스트 업데이트, 소프트 딜리트 시 문제 없이 유저-퀘스트 상태에 적용되는지 확인 부탁드립니다. 

## 💬 기타 사항
- 관련 이슈: #250 

---
