### PR TITLE
feat: 주소 관련 Entity 추가

### DIFF
--- a/src/main/java/com/explorer/gabom/domain/address/entity/Address.java
+++ b/src/main/java/com/explorer/gabom/domain/address/entity/Address.java
@@ -1,0 +1,54 @@
+package com.explorer.gabom.domain.address.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "address")
+public class Address {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	/** 연관된 시도 (FK → sido.ctpv_cd) */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sdCd", insertable = false, updatable = false)
+	private Sido sido;
+	@Column(nullable = false)
+	private String sdCd;
+
+	/** 연관된 시군구 (FK → sigungu.sgg_cd) */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sggCd", insertable = false, updatable = false)
+	private Sigungu sigungu;
+	@Column(nullable = false)
+	private String sggCd;
+
+	/** 연관된 읍면동 (FK → eupmyeondong.emd_cd) */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "emdCd", insertable = false, updatable = false)
+	private Eupmyeondong eupmyeondong;
+	@Column(nullable = false)
+	private String emdCd;
+
+	/** 상세주소 */
+	private String street;
+
+	/** 위도 */
+	@Column(nullable = false)
+	private Double latitude;
+
+	/** 경도 */
+	@Column(nullable = false)
+	private Double longitude;
+}

--- a/src/main/java/com/explorer/gabom/domain/address/entity/Address.java
+++ b/src/main/java/com/explorer/gabom/domain/address/entity/Address.java
@@ -1,5 +1,7 @@
 package com.explorer.gabom.domain.address.entity;
 
+import com.explorer.gabom.global.entity.BaseTimeEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,7 +16,7 @@ import lombok.Getter;
 @Getter
 @Entity
 @Table(name = "address")
-public class Address {
+public class Address extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/explorer/gabom/domain/address/entity/Eupmyeondong.java
+++ b/src/main/java/com/explorer/gabom/domain/address/entity/Eupmyeondong.java
@@ -1,0 +1,32 @@
+package com.explorer.gabom.domain.address.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "eupmyeondong")
+public class Eupmyeondong {
+
+	/** 읍면동 코드 (PK) */
+	@Id
+	@Column(length = 5)
+	private String emdCd;
+
+	/** 연관된 시군구 (FK → sigungu.sgg_cd) */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sggCd", nullable = false, updatable = false, insertable = false)
+	private Sigungu sigungu;
+	@Column(nullable = false)
+	private String sggCd;
+
+	/** 읍면동명 */
+	@Column(length = 100, nullable = false)
+	private String emdNm;
+}

--- a/src/main/java/com/explorer/gabom/domain/address/entity/Sido.java
+++ b/src/main/java/com/explorer/gabom/domain/address/entity/Sido.java
@@ -1,0 +1,20 @@
+package com.explorer.gabom.domain.address.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "sido")
+public class Sido {
+
+	@Id
+	@Column(length = 2)
+	private String sdCd;
+
+	@Column(length = 100, nullable = false)
+	private String sdNm;
+}

--- a/src/main/java/com/explorer/gabom/domain/address/entity/Sigungu.java
+++ b/src/main/java/com/explorer/gabom/domain/address/entity/Sigungu.java
@@ -1,0 +1,32 @@
+package com.explorer.gabom.domain.address.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "sigungu")
+public class Sigungu {
+
+	/** 시군구 코드 (PK) */
+	@Id
+	@Column(length = 3)
+	private String sggCd;
+
+	/** 연관된 시도 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "sdCd", nullable = false, updatable = false, insertable = false)
+	private Sido sido;
+	@Column(nullable = false)
+	private String sdCd;
+
+	/** 시군구명 */
+	@Column(length = 100, nullable = false)
+	private String sggNm;
+}

--- a/src/main/java/com/explorer/gabom/domain/missionproof/entity/MissionProof.java
+++ b/src/main/java/com/explorer/gabom/domain/missionproof/entity/MissionProof.java
@@ -5,11 +5,11 @@ import java.util.List;
 
 import org.hibernate.annotations.SQLDelete;
 
+import com.explorer.gabom.domain.file.entity.AttachmentFile;
 import com.explorer.gabom.domain.missionproof.type.MissionProofType;
 import com.explorer.gabom.domain.place.entity.Place;
 import com.explorer.gabom.domain.user.entity.User;
 import com.explorer.gabom.global.entity.BaseTimeEntity;
-import com.explorer.gabom.domain.file.entity.AttachmentFile;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -35,10 +35,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor
 @Table(name = "mission_proof")
 @SQLDelete(sql = "UPDATE mission_proof SET deleted_at = NOW() WHERE id = ?")
-
 public class MissionProof extends BaseTimeEntity {
 
 	@Id
@@ -80,7 +79,6 @@ public class MissionProof extends BaseTimeEntity {
 		this.imageFiles.clear();
 		this.imageFiles.addAll(newFiles);
 	}
-
 
 	public void delete() {
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,4 @@ spring:
     group:
       dev: dev
       local: local
+    active: local


### PR DESCRIPTION
## 📌 개요
주소 관련 Entity 추가

## ✅ 작업 사항
- Address Entity 추가
- Sido Entity 추가
- Sigungu Entity 추가
- Eupmyeondong Entity 추가

해당 테이블의 연관관계는 읽기 전용과 쓰기, 수정, 삭제 전용으로 나누어져 있습니다.
<p>
<img width="590" height="168" alt="image" src="https://github.com/user-attachments/assets/f2799949-b0dd-4cbb-bfcf-0f3d9cdb6595" />
<p/>
객체 그대로 가져오는 부분이 읽기 전용 필드로 Spring내에서 조회를 요청할 때 사용할 수 있습니다.
저장은 sd_cd라는 값으로 저장되고,
기존에 객체 전체를 넣어야 저장되는 방식과 다르게 
아이디만 저장해도 연관관계를 설정할 수 있도록 하였습니다.

추후 다른 Entity에서도 해당 방식으로 리팩토링 할 예정입니다.


## 🔍 리뷰 요청 포인트
- 예: 로직 흐름 자연스러운지 확인 부탁드립니다.
- 예: 유효성 검증 누락된 부분 없는지 봐주세요.

## 💬 기타 사항
- 관련 이슈: #259

---
