### PR TITLE
feat: EKS 수동 배포 및 ALB 연결 구성 추가

### DIFF
--- a/k8s/dev/gabom-app.yml
+++ b/k8s/dev/gabom-app.yml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gabom
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gabom-api
+  namespace: gabom
+spec:
+  replicas: 2
+  selector:
+    matchLabels: { app: gabom-api }
+  template:
+    metadata:
+      labels: { app: gabom-api }
+    spec:
+      containers:
+        - name: api
+          image: 675769453974.dkr.ecr.ap-northeast-2.amazonaws.com/gabom-server:dev
+          ports:
+            - containerPort: 8080
+          resources:
+            requests: { cpu: "100m", memory: "256Mi" }
+            limits:   { cpu: "500m", memory: "512Mi" }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gabom-svc
+  namespace: gabom
+spec:
+  type: NodePort
+  selector: { app: gabom-api }
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gabom-ing
+  namespace: gabom
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+    alb.ingress.kubernetes.io/healthcheck-path: /
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gabom-svc
+                port:
+                  number: 80


### PR DESCRIPTION
## 📌 개요
> EKS 클러스터(gabom-dev)에 수동 배포를 통해 애플리케이션을 외부에서 접근 가능하도록 설정하고, 기본적인 인프라 구성 완료

## ✅ 작업 사항
* ECR 이미지 푸시 (`gabom-server:dev`)
* K8s Namespace / Deployment / Service / Ingress 리소스 배포
* ALB Ingress Controller(IRSA 연동) 설치 및 도메인 확인
* ALB 헬스체크 `/` 경로로 설정
* Ingress에 `ingressClassName: alb` 명시

## 🔍 리뷰 요청 포인트
- Ingress 구성이 ALB 컨트롤러 기준으로 올바르게 설정되었는지
- 서비스 라우팅이 외부에서 정상 작동하는지

## 💬 기타 사항
- 관련 이슈: #327 
- 참고 자료: [AWS 공식 ALB Ingress Controller 설치 가이드](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
