### PR TITLE
Deploy/#329 auto dev

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,65 @@
+name: Deploy to EKS (develop)
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:6.2
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
+      rabbitmq:
+        image: rabbitmq:3-management
+        ports:
+          - 5672:5672
+          - 15672:15672
+        env:
+          RABBITMQ_DEFAULT_USER: admin
+          RABBITMQ_DEFAULT_PASS: admin
+        options: --health-cmd "rabbitmqctl status" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Print Redis Status
+        run: echo "✅ Redis 기동 완료 확인"
+
+      - name: Print RabbitMQ Status
+        run: echo "✅ RabbitMQ 기동 완료 확인"
+
+      - name: Check RDS MySQL connection
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mysql-client
+          mysql -h ${{ secrets.RDS_HOST }} -u${{ secrets.RDS_USER }} -p${{ secrets.RDS_PASSWORD }} -e "SHOW DATABASES;"
+        env:
+          MYSQL_PWD: ${{ secrets.RDS_PASSWORD }}
+
+      # TODO: Elasticsearch 연결 확인 추가 예정
+
+      - name: Setup AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: v1.29.0
+
+      - name: Update kubeconfig
+        run: aws eks update-kubeconfig --region ap-northeast-2 --name gabom-dev
+
+      - name: Deploy to EKS using Kubernetes YAML
+        run: kubectl apply -f k8s/dev/gabom-app.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,17 @@
+version: "3.8"
+
 services:
+  redis:
+    image: redis:6.2
+    container_name: redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   rabbitmq:
     image: rabbitmq:3-management
     container_name: rabbitmq
@@ -10,6 +23,11 @@ services:
       RABBITMQ_DEFAULT_PASS: admin
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   rabbitmq_data:


### PR DESCRIPTION
## 📌 개요
develop 브랜치에 머지될 때 자동으로 EKS에 배포되는 GitHub Actions 워크플로우(`deploy-dev.yml`) 추가
<img width="1139" height="908" alt="image" src="https://github.com/user-attachments/assets/0754f0b2-35f7-4e06-be89-a11e117bd2e0" />

## ✅ 작업 사항
- [x] `deploy-dev.yml` 작성: develop 브랜치 푸시 시 자동 배포
- [x] Redis, RabbitMQ, RDS 연결 상태 확인 포함
- [x] Elasticsearch 연결 TODO 처리
- [x] 로컬용 `docker-compose.yml` 작성 (Redis, RabbitMQ 포함)

## 🔍 리뷰 요청 포인트
- 워크플로우 실행 시 누락된 서비스나 절차가 없는지
- docker-compose 환경 구성에 빠진 요소는 없는지

## 💬 기타 사항
- 관련 이슈: #329 
- 오토스케일링과 헬스체크 기능은 새로운 이슈에서 작업 예정