### PR TITLE
feat: EKS 환경에서 Horizontal Pod Autoscaler(HPA) 설정 추가

### DIFF
--- a/k8s/dev/hpa.yml
+++ b/k8s/dev/hpa.yml
@@ -16,4 +16,4 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 50
+          averageUtilization: 80

--- a/k8s/dev/hpa.yml
+++ b/k8s/dev/hpa.yml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gabom-api-hpa
+  namespace: gabom
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gabom-api
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50


### PR DESCRIPTION
## 📌 개요
EKS에서 CPU 사용률 기반으로 오토스케일링이 가능하도록 HPA 설정 추가

## ✅ 작업 사항
- [x] HPA 리소스 정의 (min 2, max 5, target CPU 50%)
- [x] 부하 테스트를 통한 작동 여부 검증 완료
- [x] `/k8s/dev/hpa.yml` 적용

## 🔍 리뷰 요청 포인트
- HPA 리소스 설정 값이 적절한지
- 오토스케일링 작동 흐름이 자연스러운지

## 💬 기타 사항
- 관련 이슈: #332 