### PR TITLE
feat: Prometheus & Grafana 모니터링 시스템 구축

### DIFF
--- a/infra/monitoring/grafana-ingress.yml
+++ b/infra/monitoring/grafana-ingress.yml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  namespace: gabom-monitoring
+  annotations:
+    kubernetes.io/ingress.class: alb                           # ALB Ingress Controller 사용
+    alb.ingress.kubernetes.io/scheme: internet-facing          # 퍼블릭 ALB 생성
+    alb.ingress.kubernetes.io/target-type: ip                  # Pod IP로 직접 연결
+    alb.ingress.kubernetes.io/group.name: gabom                # Ingress 그룹핑
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'   # 80포트 노출
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: monitoring-grafana
+                port:
+                  name: http-web

--- a/infra/monitoring/values.yml
+++ b/infra/monitoring/values.yml
@@ -1,0 +1,22 @@
+grafana:
+  enabled: true
+  adminPassword: "gabom2025!"   # 로그인 비밀번호 설정
+  service:
+    type: ClusterIP             # 내부 IP만 할당
+    port: 3000
+
+  # 기본 Kubernetes 대시보드 활성화
+  defaultDashboardsEnabled: true
+
+# Prometheus 메트릭 데이터 30일간 유지
+prometheus:
+  prometheusSpec:
+    retention: "30d"
+
+# kube-controller-manager 메트릭 수집 비활성화
+kubeControllerManager:
+  enabled: false
+
+# kube-scheduler 메트릭 수집 비활성화
+kubeScheduler:
+  enabled: false


### PR DESCRIPTION
## 📌 개요
> Grafana를 외부에서 접속할 수 있도록 Ingress(ALB) 설정 및 연동 완료
<img width="1378" height="1013" alt="image" src="https://github.com/user-attachments/assets/662f40aa-bf3b-4d60-ac29-2bafa545b8f5" />


## ✅ 작업 사항
- [x] kube-prometheus-stack Helm 차트로 Grafana 설치
- [x] grafana-ingress.yml 작성 및 ALB Ingress 설정 적용
- [x] 보안 그룹 80포트 허용
- [x] Grafana 외부 접속 정상 확인

## 🔍 리뷰 요청 포인트
- Ingress 설정에서 경로 라우팅이 정확한지 확인 부탁드립니다.
- Helm 차트 배포 경로 및 네임스페이스 설정에 누락된 부분 없는지 봐주세요.

## 💬 기타 사항
- 관련 이슈: #334 
- 접속 URL: http://k8s-gabom-a67ec83a97-149221452.ap-northeast-2.elb.amazonaws.com/
- 기본 로그인 정보: admin / gabom2025!
---
