### PR TITLE
Feature: 장소 검색을 위한 Elasticsearch 도입 및 인덱싱 로직 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .env
 
+http_ca.crt
+
 HELP.md
 .gradle
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     // Elasticsearch
     implementation 'co.elastic.clients:elasticsearch-java:9.1.2'
     implementation 'org.apache.httpcomponents.client5:httpclient5'
+    implementation 'org.elasticsearch.client:elasticsearch-rest-client:9.1.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ dependencies {
 
     // RabbitMQ
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    // Elasticsearch
+    implementation 'co.elastic.clients:elasticsearch-java:9.1.2'
+    implementation 'org.apache.httpcomponents.client5:httpclient5'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,13 @@ services:
     restart: unless-stopped
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.2
+    build:
+      context: ./docker/elasticsearch
+      dockerfile: Dockerfile
     container_name: es
     environment:
       - discovery.type=single-node
-      - xpack.security.enabled=true
+      - xpack.security.enabled=false
       - xpack.security.http.ssl.enabled=false
       - ES_JAVA_OPTS=-Xms256m -Xmx256m
     ports:
@@ -25,8 +27,7 @@ services:
     volumes:
       - esdata:/usr/share/elasticsearch/data
     healthcheck:
-      # HTTP
-      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      test: [ "CMD-SHELL", "curl -sf http://localhost:9200 >/dev/null || exit 1" ]
       interval: 20s
       timeout: 7s
       retries: 15
@@ -37,7 +38,6 @@ services:
     container_name: kibana
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      - ELASTICSEARCH_SERVICEACCOUNTTOKEN=${KIBANA_SA_TOKEN}
     ports:
       - "5601:5601"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,41 @@ services:
       RABBITMQ_DEFAULT_PASS: admin
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+    restart: unless-stopped
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.1.2
+    container_name: es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=false
+      - ES_JAVA_OPTS=-Xms256m -Xmx256m
+    ports:
+      - "9200:9200"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    healthcheck:
+      # HTTP
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 20s
+      timeout: 7s
+      retries: 15
+    restart: unless-stopped
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:9.1.2
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTICSEARCH_SERVICEACCOUNTTOKEN=${KIBANA_SA_TOKEN}
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    restart: unless-stopped
 
 volumes:
   rabbitmq_data:
+  esdata:

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:9.1.2
+
+RUN elasticsearch-plugin install --batch analysis-nori
+

--- a/src/main/java/com/explorer/gabom/domain/elasticsearch/entity/PlaceSearchDoc.java
+++ b/src/main/java/com/explorer/gabom/domain/elasticsearch/entity/PlaceSearchDoc.java
@@ -1,0 +1,46 @@
+package com.explorer.gabom.domain.elasticsearch.entity;
+
+import lombok.*;
+import java.time.Instant;
+import java.util.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlaceSearchDoc {
+
+	private String id;          // ES 문서 ID = Place.id
+	private String title;       // 검색 가산치용
+	private String addressFull; // 자유 검색(주소)
+	private String emdCd;       // 필터(정확 term)
+	private Long popularity;    // 정렬(조회수 등)
+	private String status;      // 필터(승인 등)
+	private Instant createdAt;  // 정렬(최신)
+	private Double lat;         // 반경 검색 옵션
+	private Double lon;
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new HashMap<>();
+		m.put("id", id);
+		m.put("title", title);
+		m.put("address_full", addressFull);
+		m.put("emdCd", emdCd);
+		m.put("popularity", popularity);
+		m.put("status", status);
+
+		// createdAt 직렬화: ISO 문자열(권장) 또는 epochMillis 중 택1
+		if (createdAt != null) {
+			m.put("createdAt", createdAt.toString());          // ISO-8601 문자열
+			// m.put("createdAt", createdAt.toEpochMilli());   // epoch millis로 쓰고 싶을 때
+		}
+
+		if (lat != null && lon != null) {
+			m.put("location", Map.of("lat", lat, "lon", lon));
+		}
+
+		// null 제거 (ES에 null 필드 굳이 안 보냄)
+		m.values().removeIf(Objects::isNull);
+		return m;
+	}
+}

--- a/src/main/java/com/explorer/gabom/domain/elasticsearch/indexer/PlaceSearchIndexer.java
+++ b/src/main/java/com/explorer/gabom/domain/elasticsearch/indexer/PlaceSearchIndexer.java
@@ -18,33 +18,64 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Elasticsearch 색인(Indexing) 전용 서비스
+ * - DB에 저장된 Place 엔티티 및 Address 엔티티를 읽어
+ *   Elasticsearch "places_v1" 인덱스에 전송하는 역할.
+ * - 주로 전체 리인덱싱(reindexAll)이나 배치성 업데이트 용도로 사용됨.
+ */
 @Service
 @RequiredArgsConstructor
 public class PlaceSearchIndexer {
 
-	private final ElasticsearchClient es;
-	private final PlaceRepository placeRepo;
-	private final AddressRepository addressRepo;
-	private final PlaceSearchMapper mapper;
+	private final ElasticsearchClient es;       // Low-level ES Client (Java API)
+	private final PlaceRepository placeRepo;    // Place 엔티티 조회용 JPA Repository
+	private final AddressRepository addressRepo;// Address 엔티티 조회용 JPA Repository
+	private final PlaceSearchMapper mapper;     // Place + Address → PlaceSearchDoc 변환기
 
-	private static final String IDX = "places_v1";
+	private static final String IDX = "places_v1"; // ES 인덱스명 (버전 관리 차원에서 v1 사용)
 
+	/**
+	 * 전체 Place 데이터를 Elasticsearch에 다시 색인(Reindex)한다.
+	 * - 배치로 한 번에 너무 많은 데이터를 불러오지 않도록 페이징 처리한다.
+	 * - Place -> Address -> PlaceSearchDoc 변환 후 Bulk API를 이용해 인덱싱한다.
+	 *
+	 * @throws IOException Elasticsearch 통신 중 발생할 수 있는 IO 예외
+	 */
 	@Transactional(readOnly = true)
 	public void reindexAll() throws IOException {
-		int page = 0, size = 500;
+		int page = 0, size = 500; // 페이징 단위 (500개씩)
 		while (true) {
+			// 1. DB에서 Place 엔티티 페이지 단위로 조회
 			Page<Place> slice = placeRepo.findAll(PageRequest.of(page++, size));
-			if (slice.isEmpty()) break;
+			if (slice.isEmpty()) break; // 더 이상 데이터가 없으면 종료
 
+			// 2. BulkRequest 빌더 생성
 			BulkRequest.Builder br = new BulkRequest.Builder();
+
+			// 3. 각 Place 엔티티 → Address 조회 → ES 문서 변환
 			for (Place p : slice) {
-				Address a = p.getAddressId() != null ? addressRepo.findById(p.getAddressId()).orElse(null) : null;
+				// Place에 연결된 Address 엔티티 조회 (nullable)
+				Address a = p.getAddressId() != null
+							? addressRepo.findById(p.getAddressId()).orElse(null)
+							: null;
+
+				// Mapper를 통해 Place + Address → PlaceSearchDoc 변환
 				PlaceSearchDoc doc = mapper.toDoc(p, a);
-				br.operations(op -> op.index(i -> i.index(IDX).id(doc.getId()).document(doc.toMap())));
+
+				// ES Bulk 요청에 인덱스 작업 추가
+				br.operations(op -> op.index(i ->
+												 i.index(IDX)              // 대상 인덱스명
+												  .id(doc.getId())        // 문서 ID (Place PK 등 고유값)
+												  .document(doc.toMap())  // Map 형태로 직렬화한 Document
+				));
 			}
+
+			// 4. Bulk API 실행 (일괄 색인)
 			es.bulk(br.build());
 		}
+
+		// 5. 색인 강제 refresh → 즉시 검색 반영
 		es.indices().refresh(r -> r.index(IDX));
 	}
 }
-

--- a/src/main/java/com/explorer/gabom/domain/elasticsearch/indexer/PlaceSearchIndexer.java
+++ b/src/main/java/com/explorer/gabom/domain/elasticsearch/indexer/PlaceSearchIndexer.java
@@ -1,0 +1,50 @@
+package com.explorer.gabom.domain.elasticsearch.indexer;
+
+import java.io.IOException;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.explorer.gabom.domain.address.entity.Address;
+import com.explorer.gabom.domain.address.repository.AddressRepository;
+import com.explorer.gabom.domain.elasticsearch.entity.PlaceSearchDoc;
+import com.explorer.gabom.domain.elasticsearch.mapper.PlaceSearchMapper;
+import com.explorer.gabom.domain.place.entity.Place;
+import com.explorer.gabom.domain.place.repository.PlaceRepository;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceSearchIndexer {
+
+	private final ElasticsearchClient es;
+	private final PlaceRepository placeRepo;
+	private final AddressRepository addressRepo;
+	private final PlaceSearchMapper mapper;
+
+	private static final String IDX = "places_v1";
+
+	@Transactional(readOnly = true)
+	public void reindexAll() throws IOException {
+		int page = 0, size = 500;
+		while (true) {
+			Page<Place> slice = placeRepo.findAll(PageRequest.of(page++, size));
+			if (slice.isEmpty()) break;
+
+			BulkRequest.Builder br = new BulkRequest.Builder();
+			for (Place p : slice) {
+				Address a = p.getAddressId() != null ? addressRepo.findById(p.getAddressId()).orElse(null) : null;
+				PlaceSearchDoc doc = mapper.toDoc(p, a);
+				br.operations(op -> op.index(i -> i.index(IDX).id(doc.getId()).document(doc.toMap())));
+			}
+			es.bulk(br.build());
+		}
+		es.indices().refresh(r -> r.index(IDX));
+	}
+}
+

--- a/src/main/java/com/explorer/gabom/domain/elasticsearch/mapper/PlaceSearchMapper.java
+++ b/src/main/java/com/explorer/gabom/domain/elasticsearch/mapper/PlaceSearchMapper.java
@@ -1,0 +1,51 @@
+package com.explorer.gabom.domain.elasticsearch.mapper;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Component;
+
+import com.explorer.gabom.domain.address.entity.Address;
+import com.explorer.gabom.domain.elasticsearch.entity.PlaceSearchDoc;
+import com.explorer.gabom.domain.place.entity.Place;
+
+import io.micrometer.common.lang.Nullable;
+
+@Component
+public class PlaceSearchMapper {
+
+	public PlaceSearchDoc toDoc(Place p, @Nullable Address a) {
+		String full = null;
+		Double lat = null, lon = null;
+		String emd = null;
+
+		if (a != null) {
+			emd = a.getEmdCd();
+			lat = a.getLat();
+			lon = a.getLng();
+			full = Stream.of(a.getSdCd(), a.getSggCd(), a.getEmdCd(), a.getDetail())
+						 .filter(Objects::nonNull)
+						 .collect(Collectors.joining(" "));
+		}
+
+		Instant created = null;
+		if (p.getCreatedAt() != null) {
+			created = p.getCreatedAt().atZone(ZoneId.of("UTC")).toInstant();
+		}
+
+		return PlaceSearchDoc.builder()
+							 .id(String.valueOf(p.getId()))
+							 .title(p.getTitle())
+							 .addressFull(full)
+							 .emdCd(emd)
+							 .popularity(p.getViewCount() != null ? p.getViewCount().longValue() : 0L)
+							 .status(p.getStatus() != null ? p.getStatus().name() : null)
+							 .createdAt(created)
+							 .lat(lat)
+							 .lon(lon)
+							 .build();
+	}
+}

--- a/src/main/java/com/explorer/gabom/domain/elasticsearch/mapper/PlaceSearchMapper.java
+++ b/src/main/java/com/explorer/gabom/domain/elasticsearch/mapper/PlaceSearchMapper.java
@@ -14,28 +14,55 @@ import com.explorer.gabom.domain.place.entity.Place;
 
 import io.micrometer.common.lang.Nullable;
 
+/**
+ * Place + Address 엔티티를 Elasticsearch 색인용 DTO(PlaceSearchDoc)로 변환하는 매퍼.
+ * - 검색 품질을 위해 필요한 필드만 선별/가공한다.
+ * - null 안전 처리 및 시간대(UTC) 통일을 여기서 한다.
+ */
 @Component
 public class PlaceSearchMapper {
 
+	/**
+	 * JPA 엔티티를 ES 문서로 변환.
+	 *
+	 * @param p 장소 엔티티(필수)
+	 * @param a 주소 엔티티(선택: null일 수 있음 — 과거 데이터/테스트 데이터 보호)
+	 * @return PlaceSearchDoc (ES에 저장될 경량 문서)
+	 */
 	public PlaceSearchDoc toDoc(Place p, @Nullable Address a) {
-		String full = null;
+		String full = null;      // ES에서 "주소 전체 문자열" 검색용 결합 필드
 		Double lat = null, lon = null;
 		String emd = null;
 
+		// Address가 있을 때만 좌표/행정코드/주소문자열 세팅
 		if (a != null) {
 			emd = a.getEmdCd();
 			lat = a.getLat();
 			lon = a.getLng();
+
+			// 주소 검색 품질 향상: 시도/시군구/읍면동/상세를 공백으로 연결
+			// (null 제거 후 join)
 			full = Stream.of(a.getSdCd(), a.getSggCd(), a.getEmdCd(), a.getDetail())
 						 .filter(Objects::nonNull)
 						 .collect(Collectors.joining(" "));
 		}
 
+		// createdAt은 UTC 기준 Instant로 고정
+		//  - ES 정렬/필터에서 시간대 혼선을 방지
 		Instant created = null;
 		if (p.getCreatedAt() != null) {
 			created = p.getCreatedAt().atZone(ZoneId.of("UTC")).toInstant();
 		}
 
+		// ES 문서 생성:
+		//  - id         : Place PK를 문자열로 (ES 문서 ID로 사용)
+		//  - title      : 검색 가중치용 필드
+		//  - addressFull: 자유 텍스트 검색
+		//  - emdCd      : 정확 일치(term) 필터용
+		//  - popularity : 정렬(인기도) — 여기선 viewCount를 기반으로 Long 변환
+		//  - status     : 상태(승인 등) 필터
+		//  - createdAt  : 최신 정렬 등
+		//  - lat/lon    : 위치 검색(반경/거리 정렬)을 위한 좌표
 		return PlaceSearchDoc.builder()
 							 .id(String.valueOf(p.getId()))
 							 .title(p.getTitle())

--- a/src/main/java/com/explorer/gabom/domain/elasticsearch/service/PlaceSearchFacade.java
+++ b/src/main/java/com/explorer/gabom/domain/elasticsearch/service/PlaceSearchFacade.java
@@ -1,0 +1,82 @@
+package com.explorer.gabom.domain.elasticsearch.service;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.explorer.gabom.domain.place.dto.PlaceSummary;
+import com.explorer.gabom.domain.place.repository.PlaceRepository;
+import com.explorer.gabom.global.dto.PageResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceSearchFacade {
+
+	private final PlaceSearchService esSearchService; // ES에서 ID만 검색
+	private final PlaceRepository placeRepository;    // Custom 포함
+
+	/**
+	 * 검색어가 있으면: ES -> ID, DB 상세, ES 순서 보존
+	 * 검색어가 없으면: DB 경로 그대로 (emdCd 필터 + 정렬/페이징)
+	 */
+	@Transactional(readOnly = true)
+	public PageResponse<PlaceSummary> search(
+		String keyword,
+		String emdCd,
+		Double lat,
+		Double lng,
+		int page,
+		int size
+	) {
+		try {
+
+			Pageable pageable = PageRequest.of(page, size);
+
+			// 1) 키워드 없으면 DB 경로
+			if (!StringUtils.hasText(keyword)) {
+				List<Long> ids = placeRepository.findPlaceIdsForSummaryWithoutKeyword(emdCd, pageable);
+				if (ids.isEmpty()) {
+					return PageResponse.toDto(Page.empty(pageable));
+				}
+				List<PlaceSummary> rows = placeRepository.findSummariesByIds(ids);
+				long total = placeRepository.countForSummaryWithoutKeyword(emdCd);
+				return PageResponse.toDto(new PageImpl<>(rows, pageable, total));
+			}
+
+			// 2) 키워드 있으면 ES -> ID
+			PlaceSearchService.IdPage idPage = esSearchService.searchIds(
+				keyword, emdCd, lat, lng,
+				page * size, size
+			);
+
+			List<Long> ids = idPage.ids();
+			if (ids == null || ids.isEmpty()) {
+				return PageResponse.toDto(new PageImpl<>(Collections.emptyList(), pageable, 0));
+			}
+
+			// 3) DB 상세(얇게)
+			List<PlaceSummary> rows = placeRepository.findSummariesByIds(ids);
+
+			// 4) ES 순서 보존
+			Map<Long, Integer> order = new HashMap<>(ids.size() * 2);
+			for (int i = 0; i < ids.size(); i++)
+				order.put(ids.get(i), i);
+			rows.sort(Comparator.comparingInt(ps -> order.getOrDefault(ps.getPlaceId(), Integer.MAX_VALUE)));
+
+			// 5) 응답 (total은 ES total)
+			return PageResponse.toDto(new PageImpl<>(rows, pageable, idPage.total()));
+
+		} catch (IOException e) {
+			throw new IllegalStateException("ElasticSearch 검색 중 오류", e);
+		}
+	}
+}

--- a/src/main/java/com/explorer/gabom/domain/elasticsearch/service/PlaceSearchService.java
+++ b/src/main/java/com/explorer/gabom/domain/elasticsearch/service/PlaceSearchService.java
@@ -1,0 +1,64 @@
+package com.explorer.gabom.domain.elasticsearch.service;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import io.micrometer.common.lang.Nullable;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceSearchService {
+
+	private final ElasticsearchClient es;
+	private static final String IDX = "places_v1";
+
+	public IdPage searchIds(@Nullable String keyword,
+							@Nullable String emdCd,
+							@Nullable Double lat, @Nullable Double lon,
+							int from, int size) throws IOException {
+
+		SearchRequest.Builder sb = new SearchRequest.Builder()
+			.index(IDX)
+			.from(from)
+			.size(size)
+			.trackTotalHits(t -> t.enabled(true))          // 총건수 정확히 받기
+			.source(sc -> sc.fetch(false))                 // _source 제외 → id만
+
+			.query(qb -> qb.bool(b -> {
+				if (keyword != null && !keyword.isBlank()) {
+					b.should(sh -> sh.multiMatch(mm -> mm
+						.query(keyword)
+						.fields("title^3,address_full^2")));
+					b.minimumShouldMatch("1");
+				}
+				if (emdCd != null && !emdCd.isBlank()) {
+					b.filter(f -> f.term(t -> t.field("emdCd").value(emdCd)));
+				}
+				return b;
+			}))
+
+			// 정렬: 점수 → 인기 → 최신
+			// (geo 정렬은 클라이언트 API가 버전별로 달라 실수 잦아서 일단 제외)
+			.sort(so -> so.field(f -> f.field("_score").order(SortOrder.Desc)))
+			.sort(so -> so.field(f -> f.field("popularity").order(SortOrder.Desc)))
+			.sort(so -> so.field(f -> f.field("createdAt").order(SortOrder.Desc)));
+
+		SearchResponse<Void> resp = es.search(sb.build(), Void.class);
+
+		List<Long> ids = resp.hits().hits().stream()
+							 .map(h -> Long.valueOf(h.id()))
+							 .toList();
+
+		long total = resp.hits().total() != null ? resp.hits().total().value() : ids.size();
+		return new IdPage(ids, total);
+	}
+
+	public record IdPage(List<Long> ids, long total) {}
+}

--- a/src/main/java/com/explorer/gabom/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/explorer/gabom/domain/place/controller/PlaceController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.explorer.gabom.domain.elasticsearch.service.PlaceSearchFacade;
 import com.explorer.gabom.domain.place.dto.PlaceDetail;
 import com.explorer.gabom.domain.place.dto.PlaceSummary;
 import com.explorer.gabom.domain.place.dto.request.PlaceCreateRequest;
@@ -40,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PlaceController implements PlaceControllerDocs {
 
 	private final PlaceService placeService;
+	private final PlaceSearchFacade placeSearchFacade;
 
 	// 탐험 장소 생성
 	@PostMapping
@@ -100,4 +102,21 @@ public class PlaceController implements PlaceControllerDocs {
 		Long deletePlaceId = placeService.deletePlace(placeId, userDetails.getUserId());
 		return ResponseEntity.ok(ApiResponse.success("장소가 삭제되었습니다.", deletePlaceId));
 	}
+
+	// ES + DB 혼합 검색 (키워드 있으면 ES, 없으면 DB 경로)
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<PageResponse<PlaceSummary>>> searchPlaces(
+		@RequestParam(required = false) String keyword,
+		@RequestParam(required = false) String emdCd,
+		@RequestParam(required = false) Double lat,
+		@RequestParam(required = false, name = "lng") Double lng,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		PageResponse<PlaceSummary> result =
+			placeSearchFacade.search(keyword, emdCd, lat, lng, page, size);
+
+		return ResponseEntity.ok(ApiResponse.success("장소 검색 성공", result));
+	}
+
 }

--- a/src/main/java/com/explorer/gabom/domain/place/controller/PlaceControllerDocs.java
+++ b/src/main/java/com/explorer/gabom/domain/place/controller/PlaceControllerDocs.java
@@ -130,4 +130,41 @@ public interface PlaceControllerDocs {
 		@Parameter(hidden = true)
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	);
+
+	@Operation(
+		summary = "장소 검색 (ES + DB)",
+		description = """
+        검색어가 있으면 Elasticsearch에서 ID만 검색 후 DB에서 상세를 조회하고, 
+        검색어가 없으면 DB에서 바로 조회합니다.
+        - 파라미터: keyword(선택), emdCd(선택), lat/lon(선택), page, size
+        - 정렬은 ES가 수행(키워드 있을 때), DB 경로는 기본 정렬(viewCount desc, createdAt desc)
+        예)
+          /api/places/search?keyword=카페&emdCd=11110101&page=0&size=20
+          /api/places/search?emdCd=11110101&page=0&size=20
+          /api/places/search?keyword=분식&lat=37.57&lon=126.98&page=0&size=10
+        """
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "장소 검색 성공")
+	})
+	ResponseEntity<?> searchPlaces(
+		@Parameter(description = "검색 키워드 (선택)")
+		@RequestParam(required = false) String keyword,
+
+		@Parameter(description = "읍면동 코드 (10자리, 선택) ex.\"1214030000\"")
+		@RequestParam(required = false) @Pattern(regexp = "^\\d{10}$") String emdCd,
+
+		@Parameter(description = "현재 위치의 위도 (선택)")
+		@RequestParam(required = false) Double lat,
+
+		@Parameter(description = "현재 위치의 경도 (선택). Facade 시그니처에 맞춰 이름은 'lon'")
+		@RequestParam(required = false, name = "lon") Double lon,
+
+		@Parameter(description = "페이지 번호 (기본 0)")
+		@RequestParam(defaultValue = "0") int page,
+
+		@Parameter(description = "페이지 크기 (기본 10)")
+		@RequestParam(defaultValue = "10") int size
+	);
+
 }

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryCustom.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryCustom.java
@@ -2,6 +2,8 @@ package com.explorer.gabom.domain.place.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+
 import com.explorer.gabom.domain.place.dto.PlaceSummary;
 import com.explorer.gabom.domain.place.dto.request.PlaceSearchCond;
 import com.explorer.gabom.global.dto.PageResponse;
@@ -10,6 +12,15 @@ import com.querydsl.core.Tuple;
 public interface PlaceRepositoryCustom {
 
 	PageResponse<PlaceSummary> findPlaceSummaries(PlaceSearchCond cond);
+
+	/** ES에서 받은 ids로 얇은 요약 상세 조회 */
+	List<PlaceSummary> findSummariesByIds(List<Long> ids);
+
+	/** 키워드 없을 때: DB 경로에서 ID만 페이지로 */
+	List<Long> findPlaceIdsForSummaryWithoutKeyword(String emdCd, Pageable pageable);
+
+	/** 키워드 없을 때: 전체 개수 */
+	long countForSummaryWithoutKeyword(String emdCd);
 
 	/**
 	 * 주어진 위도(lat), 경도(lon) 기준으로

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.explorer.gabom.domain.address.entity.QAddress;
@@ -42,6 +43,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
+@Repository
 @RequiredArgsConstructor
 @Transactional
 public class PlaceRepositoryImpl implements PlaceRepositoryCustom {

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
@@ -101,9 +101,18 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 
 			NumberExpression<Double> avgRating   = mp.starRating.avg().coalesce(0.0);
 			NumberExpression<Long>   proofCount  = mp.id.count().coalesce(0L);
+			NumberExpression<Long>   viewCount   = place.viewCount.coalesce(0).castToNum(Long.class);
+			NumberExpression<Long>   popularity  = viewCount.add(proofCount);
 
-			// 여기서 통일된 정렬 적용
-			applySortSafe(q, cond.getPageable(), distanceExpr, proofCount, avgRating);
+			for (Sort.Order o : cond.getPageable().getSort()) {
+				boolean asc = o.isAscending();
+				switch (o.getProperty()) {
+					case "rating"     -> q.orderBy(new OrderSpecifier<>(asc ? Order.ASC : Order.DESC, avgRating));
+					case "popularity" -> q.orderBy(new OrderSpecifier<>(asc ? Order.ASC : Order.DESC, popularity));
+					case "createdAt"  -> q.orderBy(new OrderSpecifier<>(asc ? Order.ASC : Order.DESC, place.createdAt));
+					case "distance"   -> q.orderBy(new OrderSpecifier<>(asc ? Order.ASC : Order.DESC, distanceExpr));
+				}
+			}
 		}
 
 		// 페이징

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
@@ -99,18 +99,9 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 
 			NumberExpression<Double> avgRating   = mp.starRating.avg().coalesce(0.0);
 			NumberExpression<Long>   proofCount  = mp.id.count().coalesce(0L);
-			NumberExpression<Long>   viewCount   = place.viewCount.coalesce(0).castToNum(Long.class);
-			NumberExpression<Long>   popularity  = viewCount.add(proofCount);
 
-			for (Sort.Order o : cond.getPageable().getSort()) {
-				boolean asc = o.isAscending();
-				switch (o.getProperty()) {
-					case "rating"     -> q.orderBy(new OrderSpecifier<>(asc ? Order.ASC : Order.DESC, avgRating));
-					case "popularity" -> q.orderBy(new OrderSpecifier<>(asc ? Order.ASC : Order.DESC, popularity));
-					case "createdAt"  -> q.orderBy(new OrderSpecifier<>(asc ? Order.ASC : Order.DESC, place.createdAt));
-					case "distance" -> q.orderBy(new OrderSpecifier<>(asc ? Order.ASC : Order.DESC, distanceExpr));
-				}
-			}
+			// 여기서 통일된 정렬 적용
+			applySortSafe(q, cond.getPageable(), distanceExpr, proofCount, avgRating);
 		}
 
 		// 페이징

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
@@ -26,6 +26,7 @@ import com.explorer.gabom.domain.place.mapper.PlaceSummaryMapper;
 import com.explorer.gabom.domain.title.entity.QTitle;
 import com.explorer.gabom.domain.user.entity.QUser;
 import com.explorer.gabom.global.dto.PageResponse;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;

--- a/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
+++ b/src/main/java/com/explorer/gabom/domain/place/repository/PlaceRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.explorer.gabom.domain.place.repository;
 import static com.explorer.gabom.domain.address.entity.QAddress.*;
 import static com.explorer.gabom.domain.place.entity.QPlace.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -24,6 +25,8 @@ import com.explorer.gabom.domain.user.entity.QUser;
 import com.explorer.gabom.global.dto.PageResponse;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -124,6 +127,126 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 
 		return PageResponse.toDto(new PageImpl<>(content, pageable, total));
 	}
+
+	// 2-1) ES → DB 상세: ids로 얇게 조회
+	@Override
+	@Transactional(readOnly = true)
+	public List<PlaceSummary> findSummariesByIds(List<Long> ids) {
+		if (ids == null || ids.isEmpty()) return List.of();
+
+		QPlaceFile placeFile = QPlaceFile.placeFile;
+		QAttachmentFile file = QAttachmentFile.attachmentFile;
+		QUser writer = QUser.user;
+		QAttachmentFile subFile = new QAttachmentFile("sf");
+		QTitle title = new QTitle("title");
+
+		Expression<Double> distanceSel =
+			ExpressionUtils.as(Expressions.nullExpression(Double.class), "distance");
+
+		Expression<Long> proofCountSel =
+			ExpressionUtils.as(Expressions.nullExpression(Long.class), "proofCount");
+
+		List<Tuple> tuples = queryFactory
+			.select(
+				place.id,
+				place.title,
+				address,
+				address.lat,
+				address.lng,
+				place.viewCount,
+				writer.id,
+				writer.nickname,
+				writer.level,
+				writer.title.name,
+				file.fileId,
+				file.filePath,
+				distanceSel,
+				proofCountSel
+			)
+			.from(place)
+			.join(place.user, writer)
+			.leftJoin(writer.title, title)
+			.leftJoin(address).on(place.addressId.eq(address.id))
+			.leftJoin(placeFile).on(placeFile.place.eq(place))
+			.leftJoin(file).on(
+				file.eq(placeFile.file),
+				file.fileId.eq(JPAExpressions
+								   .select(subFile.fileId)
+								   .from(subFile)
+								   .join(placeFile).on(placeFile.file.eq(subFile))
+								   .where(placeFile.place.eq(place), subFile.deleted.isFalse())
+								   .orderBy(subFile.orderIdx.asc())
+								   .limit(1))
+			)
+			.where(
+				place.deletedAt.isNull(),
+				place.id.in(ids)
+			)
+			.fetch();
+
+		return tuples.stream().map(PlaceSummaryMapper::fromTuple).toList();
+	}
+
+	// 2-2) 키워드 없음: ID만 페이지로 (필요 시 정렬 정책 보강)
+	@Override
+	@Transactional(readOnly = true)
+	public List<Long> findPlaceIdsForSummaryWithoutKeyword(String emdCd, Pageable pageable) {
+		BooleanBuilder where = new BooleanBuilder()
+			.and(place.deletedAt.isNull());
+
+		if (emdCd != null && !emdCd.isBlank()) {
+			where.and(address.emdCd.eq(emdCd));
+		}
+
+		// 정렬: pageable이 주는 정렬을 해석 (기본 viewCount desc, createdAt desc)
+		List<OrderSpecifier<?>> orders = new ArrayList<>();
+		if (pageable.getSort().isSorted()) {
+			for (Sort.Order o : pageable.getSort()) {
+				boolean asc = o.isAscending();
+				switch (o.getProperty()) {
+					case "viewCount" -> orders.add(asc ? place.viewCount.asc() : place.viewCount.desc());
+					case "createdAt" -> orders.add(asc ? place.createdAt.asc() : place.createdAt.desc());
+					default -> {} // 무시
+				}
+			}
+		}
+		if (orders.isEmpty()) {
+			orders.add(place.viewCount.desc());
+			orders.add(place.createdAt.desc());
+		}
+
+		return queryFactory
+			.select(place.id)
+			.from(place)
+			.leftJoin(address).on(place.addressId.eq(address.id))
+			.where(where)
+			.orderBy(orders.toArray(new OrderSpecifier<?>[0]))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+
+	// 2-3) 키워드 없음: total 카운트
+	@Override
+	@Transactional(readOnly = true)
+	public long countForSummaryWithoutKeyword(String emdCd) {
+		BooleanBuilder where = new BooleanBuilder()
+			.and(place.deletedAt.isNull());
+
+		if (emdCd != null && !emdCd.isBlank()) {
+			where.and(address.emdCd.eq(emdCd));
+		}
+
+		Long total = queryFactory
+			.select(place.count())
+			.from(place)
+			.leftJoin(address).on(place.addressId.eq(address.id))
+			.where(where)
+			.fetchOne();
+
+		return total == null ? 0L : total;
+	}
+
 
 	@Override
 	public List<Tuple> findWithinRadius(double lat, double lon, double minKm, double maxKm) {

--- a/src/main/java/com/explorer/gabom/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/explorer/gabom/global/config/ElasticsearchConfig.java
@@ -1,0 +1,41 @@
+package com.explorer.gabom.global.config;
+
+import java.net.URI;
+
+import org.apache.hc.core5.http.HttpHost;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.elasticsearch.client.RestClient;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+
+@Configuration
+public class ElasticsearchConfig {
+
+	@Bean
+	public RestClient restClient(@Value("${elasticsearch.url}") String url) {
+		// url: http://localhost:9200  (반드시 http:// 포함, 공백/따옴표 없이)
+		URI uri = URI.create(url.trim());
+		String scheme = uri.getScheme();
+		String host = uri.getHost();
+		int port = (uri.getPort() == -1)
+				   ? ("https".equalsIgnoreCase(scheme) ? 443 : 80)
+				   : uri.getPort();
+
+		return RestClient.builder(new org.apache.http.HttpHost(host, port, scheme)).build();
+	}
+
+	@Bean
+	public ElasticsearchTransport transport(RestClient restClient) {
+		return new RestClientTransport(restClient, new JacksonJsonpMapper());
+	}
+
+	@Bean
+	public ElasticsearchClient elasticsearchClient(ElasticsearchTransport transport) {
+		return new ElasticsearchClient(transport);
+	}
+}

--- a/src/main/java/com/explorer/gabom/global/config/StartupTask.java
+++ b/src/main/java/com/explorer/gabom/global/config/StartupTask.java
@@ -1,0 +1,23 @@
+package com.explorer.gabom.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.explorer.gabom.domain.elasticsearch.indexer.PlaceSearchIndexer;
+
+@Configuration
+@RequiredArgsConstructor
+public class StartupTask {
+
+	private final PlaceSearchIndexer indexer;
+
+	@Bean
+	CommandLineRunner runIndexerOnStartup() {
+		return args -> {
+			indexer.reindexAll(); // 앱 시작 시 실행
+		};
+	}
+}
+

--- a/src/main/java/com/explorer/gabom/global/util/OrderPreserver.java
+++ b/src/main/java/com/explorer/gabom/global/util/OrderPreserver.java
@@ -1,0 +1,19 @@
+package com.explorer.gabom.global.util;
+
+import java.util.*;
+import java.util.function.Function;
+
+public final class OrderPreserver {
+
+	private OrderPreserver() {}
+
+	/** refOrder의 순서를 기준으로 items를 재정렬한다. (키 추출 함수 필요) */
+	public static <T, K> List<T> reorderLike(List<T> items, List<K> refOrder, Function<T, K> keyFn) {
+		if (items == null || items.isEmpty() || refOrder == null || refOrder.isEmpty()) return items;
+		Map<K, Integer> pos = new HashMap<>(refOrder.size() * 2);
+		for (int i = 0; i < refOrder.size(); i++) pos.put(refOrder.get(i), i);
+
+		items.sort(Comparator.comparingInt(o -> pos.getOrDefault(keyFn.apply(o), Integer.MAX_VALUE)));
+		return items;
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,7 +24,7 @@ spring:
     password: admin
 
   elasticsearch:
-    url: http://localhost:9200
+    url: ${elasticsearch.url}
     username: elastic
     password: ${ES_PASSWORD}
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,11 @@ spring:
     username: admin
     password: admin
 
+  elasticsearch:
+    url: http://localhost:9200
+    username: elastic
+    password: ${ES_PASSWORD}
+
   # 이메일 인증 시 필요
   mail:
     host: smtp.gmail.com

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,6 +28,11 @@ spring:
     username: admin
     password: admin
 
+  elasticsearch:
+    url: ${elasticsearch.url}
+    username: elastic
+    password: ${ES_PASSWORD}
+
   # 이메일 인증 시 필요
   mail:
     host: smtp.gmail.com


### PR DESCRIPTION
## 📌 개요
elasticsearch 도입

## ✅ 작업 사항
- [ ] Elasticsearch 연동
ElasticsearchConfig 추가하여 ElasticsearchClient Bean 구성
인덱스명: places_v1
- [ ] nori_tokenizer 기반 한국어 형태소 분석기(ko_nori) 적용
- [ ] PlaceSearchDoc 엔티티 정의 (ES Document)
PlaceSearchMapper: Place + Address → PlaceSearchDoc 변환
- [ ] PlaceSearchIndexer 서비스 구현
reindexAll(): DB → ES 대량 인덱싱 지원 (페이지네이션 + Bulk API)
실행 시 모든 Place 데이터 ES 인덱스에 저장
인덱싱 완료 후 refresh 처리
- [ ] PlaceRepositoryImpl 에서 정렬/검색 조건 강화
- [ ] Swagger 추가

## 🔍 리뷰 요청 포인트
- 예: 로직 흐름 자연스러운지 확인 부탁드립니다.
- 예: 유효성 검증 누락된 부분 없는지 봐주세요.

## 💬 기타 사항
- 관련 이슈: #325 
- 참고 자료: 테스트 결과는 노션 확인해주세요

---
