### PR TITLE
feat: 루트 경로 허용 및 RootController 생성

### DIFF
--- a/src/main/java/com/explorer/gabom/global/RootController.java
+++ b/src/main/java/com/explorer/gabom/global/RootController.java
@@ -1,0 +1,13 @@
+package com.explorer.gabom.global;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RootController {
+
+    @GetMapping("/")
+    public String root() {
+        return "Hello World!";
+    }
+}

--- a/src/main/java/com/explorer/gabom/global/config/SecurityConfig.java
+++ b/src/main/java/com/explorer/gabom/global/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 			// 정적/문서/WS 경로 인증 제외로 500/401 해소
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-				.requestMatchers(
+				.requestMatchers("/",
 					"/api/auth/**",
 					"/v3/api-docs/**",
 					"/swagger-ui/**",


### PR DESCRIPTION
## 📌 개요
루트 경로(`/`) 접근 시 401이 발생하던 문제를 해결하고, 브라우저 또는 모니터링 툴에서 진입 가능하도록 기본 응답 구성

## ✅ 작업 사항
- [x] SecurityConfig에 `/` 경로 permitAll 추가
- [x] RootController 생성 (`/` → "Hello World!" 반환)

## 🔍 리뷰 요청 포인트
- Security 설정에서 "/" 허용 처리 적절한지

## 🔗 관련 이슈
- 없음